### PR TITLE
Sourceforge Ticket 45: Eureka shouldn't store user specific data in the map WAD 

### DIFF
--- a/src/lib_file.cc
+++ b/src/lib_file.cc
@@ -336,7 +336,9 @@ SString GetAbsolutePath(const SString &path)
 	return stringBuffer.data();
 }
 
-//assuming fl_filename_relative can be safely wrapped the same way filename_absolute is
+// Thu 12 May 2022
+// Assuming fl_filename_relative can be safely wrapped as above
+//
 SString GetRelativePath(const SString &path)
 {
         size_t sz = 64;

--- a/src/lib_file.cc
+++ b/src/lib_file.cc
@@ -220,7 +220,7 @@ static void FilenameStripBase(char *buffer)
 //
 // Clears the basename
 //
-static void FilenameStripBase(SString &path)
+void FilenameStripBase(SString &path)
 {
 	if(path.empty())
 	{

--- a/src/lib_file.cc
+++ b/src/lib_file.cc
@@ -336,6 +336,22 @@ SString GetAbsolutePath(const SString &path)
 	return stringBuffer.data();
 }
 
+//assuming fl_filename_relative can be safely wrapped the same way filename_absolute is
+SString GetRelativePath(const SString &path)
+{
+        size_t sz = 64;
+        std::vector<char> stringBuffer;
+
+        do
+        {
+                sz *= 2;
+                stringBuffer.resize(sz);
+                fl_filename_relative(stringBuffer.data(), (int)stringBuffer.size(), path.c_str());
+        } while(stringBuffer.back() == '\0' && stringBuffer[stringBuffer.size() - 2] != 0);
+
+        return stringBuffer.data();
+}
+
 bool FileCopy(const SString &src_name, const SString &dest_name)
 {
 	char buffer[1024];

--- a/src/lib_file.h
+++ b/src/lib_file.h
@@ -41,6 +41,7 @@ bool MatchExtension(const SString &filename, const SString &ext);
 SString ReplaceExtension(const SString &filename, const SString &ext);
 SString GetBaseName(const SString &path);
 bool FilenameIsBare(const SString &filename);
+void FilenameStripBase(SString &path);
 SString FilenameReposition(const SString &filename, const SString &othername);
 SString FilenameGetPath(const SString &filename);
 SString GetAbsolutePath(const SString &path);

--- a/src/lib_file.h
+++ b/src/lib_file.h
@@ -44,6 +44,7 @@ bool FilenameIsBare(const SString &filename);
 SString FilenameReposition(const SString &filename, const SString &othername);
 SString FilenameGetPath(const SString &filename);
 SString GetAbsolutePath(const SString &path);
+SString GetRelativePath(const SString &path);
 
 // file utilities
 bool FileExists(const SString &filename);

--- a/src/m_files.cc
+++ b/src/m_files.cc
@@ -931,6 +931,7 @@ bool Instance::M_ParseEurekaLump(const Wad_file *wad, bool keep_cmd_line_args)
 		else if (line == "resource")
 		{
 			SString res = value;
+                        SString resBackup = res;
 
 			// if not found at absolute location, try same place as PWAD
 
@@ -941,6 +942,15 @@ bool Instance::M_ParseEurekaLump(const Wad_file *wad, bool keep_cmd_line_args)
 				res = FilenameReposition(value, wad->PathName());
 				gLog.printf("  trying: %s\n", res.c_str());
 			}
+
+                        if (! FileExists(res))
+                        {
+                                //now try relative to PWAD by prepending PWAD path
+                                SString pwadPath = FilenameGetPath(wad->PathName());
+                                pwadPath += DIR_SEP_STR;
+                                res = (pwadPath += resBackup);
+                                gLog.printf("  trying: %s\n", res.c_str());
+                        }
 
 			if (! FileExists(res) && !new_iwad.empty())
 			{

--- a/src/m_files.cc
+++ b/src/m_files.cc
@@ -1025,12 +1025,30 @@ void Instance::M_WriteEurekaLump(Wad_file *wad) const
 	if (!loaded.portName.empty())
 		lump->Printf("port %s\n", loaded.portName.c_str());
 
+        //remember pwd
+        static char old_dir[FL_PATH_MAX];
+
+        if (cwd(old_dir, sizeof(old_dir)) == NULL)
+        {
+                old_dir[0] = 0;
+        }
+
+        //assuming the edit_wad is the pwad currently being edited
+        SString current_pwad_dir = FilenameGetPath(wad.master.edit_wad);
+        FileChangeDir(current_pwad_dir);
+
 	for (const SString &resource : loaded.resourceList)
 	{
 		SString relative_name = GetRelativePath(resource);
 
 		lump->Printf("resource %s\n", relative_name.c_str());
 	}
+
+        //restore pwd
+        if (old_dir[0])
+        {
+                FileChangeDir(old_dir);
+        }
 
 	wad->writeToDisk();
 }

--- a/src/m_files.cc
+++ b/src/m_files.cc
@@ -1036,7 +1036,7 @@ void Instance::M_WriteEurekaLump(Wad_file *wad) const
 		lump->Printf("port %s\n", loaded.portName.c_str());
 
         //remember pwd
-        static char old_dir[FL_PATH_MAX];
+        char old_dir[FL_PATH_MAX];
 
         if (getcwd(old_dir, sizeof(old_dir)) == NULL)
         {

--- a/src/m_files.cc
+++ b/src/m_files.cc
@@ -1027,9 +1027,9 @@ void Instance::M_WriteEurekaLump(Wad_file *wad) const
 
 	for (const SString &resource : loaded.resourceList)
 	{
-		SString absolute_name = GetAbsolutePath(resource);
+		SString relative_name = GetRelativePath(resource);
 
-		lump->Printf("resource %s\n", absolute_name.c_str());
+		lump->Printf("resource %s\n", relative_name.c_str());
 	}
 
 	wad->writeToDisk();

--- a/src/m_files.cc
+++ b/src/m_files.cc
@@ -1028,14 +1028,13 @@ void Instance::M_WriteEurekaLump(Wad_file *wad) const
         //remember pwd
         static char old_dir[FL_PATH_MAX];
 
-        if (cwd(old_dir, sizeof(old_dir)) == NULL)
+        if (getcwd(old_dir, sizeof(old_dir)) == NULL)
         {
                 old_dir[0] = 0;
         }
 
-        //assuming the edit_wad is the pwad currently being edited
-        SString current_pwad_dir = FilenameGetPath(wad.master.edit_wad);
-        FileChangeDir(current_pwad_dir);
+        SString current_pwad_path = FilenameGetPath(wad->PathName());
+        FileChangeDir(current_pwad_path);
 
 	for (const SString &resource : loaded.resourceList)
 	{


### PR DESCRIPTION
Solved [this ticket](https://sourceforge.net/p/eureka-editor/tickets/45/). The Eureka lump shouldn't store user data in the form of absolute paths in the map WAD. The changes made affect only the Eureka lump writer and parser.