### PR TITLE
Doom Builder-style neighbor selection by texture and height

### DIFF
--- a/bindings.cfg
+++ b/bindings.cfg
@@ -19,6 +19,8 @@ general	WHEEL_DOWN	Zoom	-1
 
 render	LAX-WHEEL_UP	3D_WHEEL_Move	48
 render	LAX-WHEEL_DOWN	3D_WHEEL_Move	48
+render	SHIFT-MOUSE1	SelectNeighbors  texture
+render	CMD-MOUSE1	SelectNeighbors  height
 
 #
 # ---- Browser only ------------

--- a/src/Instance.h
+++ b/src/Instance.h
@@ -137,6 +137,7 @@ public:
 	void CMD_SEC_SwapFlats();
 	void CMD_Select();
 	void CMD_SelectAll();
+	void CMD_SelectNeighbors();
 	void CMD_SetVar();
 	void CMD_Shrink();
 	void CMD_TestMap();
@@ -211,6 +212,8 @@ public:
 	bool RecUsed_ParseUser(const std::vector<SString> &tokens);
 	void RecUsed_WriteUser(std::ostream &os) const;
 	void RedrawMap();
+	void SelectNeighborLines(int objnum, SString option, byte parts, bool forward);
+	void SelectNeighborSectors(int objnum, SString option, byte parts);
 	void Selection_Clear(bool no_save = false);
 	void Selection_InvalidateLast();
 	void Selection_NotifyBegin();

--- a/src/e_commands.cc
+++ b/src/e_commands.cc
@@ -131,6 +131,39 @@ void Instance::CMD_UnselectAll()
 	RedrawMap();
 }
 
+void Instance::CMD_SelectNeighbors()
+{
+	SString option = EXEC_Param[0];
+
+	if (edit.mode != ObjType::linedefs && edit.mode != ObjType::sectors)
+		return;
+	
+	if (option != "height" && option != "texture")
+		return;
+		
+	int num = edit.highlight.num;
+	byte parts = edit.highlight.parts;
+		
+	if (edit.Selected->get(num) && edit.Selected->get_ext(num) & parts)
+	{
+		CMD_UnselectAll();
+	}
+	else
+	{
+		edit.Selected->set_ext(num, edit.Selected->get_ext(num) | parts);
+		if (edit.mode == ObjType::linedefs)
+		{
+			SelectNeighborLines(num, option, parts, true);
+			SelectNeighborLines(num, option, parts, false);
+		}
+		else
+		{
+			SelectNeighborSectors(num, option, parts);
+		}
+		
+	}
+	RedrawMap();
+}
 
 void Instance::CMD_InvertSelection()
 {
@@ -1539,6 +1572,13 @@ static editor_command_t  command_table[] =
 
 	{	"UnselectAll",	"Edit",
 		&Instance::CMD_UnselectAll
+	},
+	
+	{
+		"SelectNeighbors", "Edit",
+		&Instance::CMD_SelectNeighbors,
+		/* flags */ NULL,
+		/* keywords */ "height texture"
 	},
 
 	{	"InvertSelection",	"Edit",

--- a/src/e_commands.cc
+++ b/src/e_commands.cc
@@ -141,6 +141,9 @@ void Instance::CMD_SelectNeighbors()
 	if (option != "height" && option != "texture")
 		return;
 		
+	if (edit.highlight.num < 0)
+		return;
+		
 	int num = edit.highlight.num;
 	byte parts = edit.highlight.parts;
 		

--- a/src/e_main.cc
+++ b/src/e_main.cc
@@ -968,8 +968,7 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 			
 		LineDef *line2 = level.linedefs[i];
 			
-		if ((forward && line2->start == line1->end)
-			|| (!forward && line2->end == line1->start))
+		if ((forward && line2->start == line1->end) || (!forward && line2->end == line1->start))
 		{
 			SideDef *side1 = frontside ? line1->Right(level) : line1->Left(level);
 			SideDef *side2 = frontside ? line2->Right(level) : line2->Left(level);
@@ -979,17 +978,14 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 			if (option == "texture")
 			{
 				if (line1->OneSided() || (parts & PART_RT_RAIL || parts & PART_LF_RAIL))
-				{
 					match = (side2->MidTex() == side1->MidTex() && side2->MidTex() != "-");
-				}
+
 				else if (parts & PART_RT_LOWER || parts & PART_LF_LOWER)
-				{
 					match = (side2->LowerTex() == side1->LowerTex() && side2->LowerTex() != "-");
-				}
+
 				else if (parts & PART_RT_UPPER || parts & PART_LF_UPPER)
-				{
 					match = (side2->UpperTex() == side1->UpperTex() && side2->UpperTex() != "-");
-				}
+
 			}
 			else
 			{
@@ -1006,17 +1002,14 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 					l2back = line2->Left(level)->SecRef(level);
 				}
 				if (line1->OneSided())
-				{
 					match = (l1front->floorh == l2front->floorh && l1front->ceilh == l2front->ceilh);
-				}
+
 				else if (parts & PART_RT_LOWER || parts & PART_LF_LOWER)
-				{
 					match = (l1front->floorh == l2front->floorh && l1back->floorh == l2back->floorh);
-				}
+
 				else if (parts & PART_RT_UPPER || parts & PART_LF_UPPER)
-				{
 					match = (l1front->ceilh == l2front->ceilh && l1back->ceilh == l2back->ceilh);
-				}
+
 				else
 				{
 					int lowestceil1 = std::min(l1front->ceilh, l1back->ceilh);
@@ -1055,7 +1048,58 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 
 void Instance::SelectNeighborSectors(int objnum, SString option, byte parts)
 {	
-	Beep("Sectors");
+	Sector *sector1 = level.sectors[objnum];
+	
+	for (int i = 0; (long unsigned int)i < level.linedefs.size(); i++)
+	{
+		LineDef *line = level.linedefs[i];
+		
+		if (line->OneSided())
+			continue;
+			
+		if (line->Right(level)->sector == objnum || line->Left(level)->sector == objnum)
+		{
+			Sector *sector2;
+			int sectornum;
+			
+			bool match = false;
+			
+			if (line->Right(level)->sector == objnum)
+			{
+				sector2 = line->Left(level)->SecRef(level);
+				sectornum = line->Left(level)->sector;
+			}
+			else
+			{
+				sector2 = line->Right(level)->SecRef(level);
+				sectornum = line->Right(level)->sector;
+			}
+			
+			if (edit.Selected->get(sectornum))
+				continue;
+				
+			if (option == "texture")
+			{
+				if (parts & PART_FLOOR)
+					match = (sector1->FloorTex() == sector2->FloorTex());
+				else
+					match = (sector1->CeilTex() == sector2->CeilTex());
+			}
+			else
+			{
+				if (parts & PART_FLOOR)
+					match = (sector1->floorh == sector2->floorh);
+				else
+					match = (sector1->ceilh == sector2->ceilh);
+			}
+			
+			if (match)
+			{
+				edit.Selected->set_ext(sectornum, parts);
+				SelectNeighborSectors(sectornum, option, parts);
+			}
+		}
+	}
 
 }
 

--- a/src/e_main.cc
+++ b/src/e_main.cc
@@ -966,8 +966,11 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 		if (objnum == i || edit.Selected->get(i))
 			continue;
 			
-		LineDef *line2 = level.linedefs[i];
-			
+		LineDef *line2 = level.linedefs[i];		
+				
+		if (line1->OneSided() != line2->OneSided())
+					continue;
+				
 		if ((forward && line2->start == line1->end) || (!forward && line2->end == line1->start))
 		{
 			SideDef *side1 = frontside ? line1->Right(level) : line1->Left(level);
@@ -989,9 +992,6 @@ void Instance::SelectNeighborLines(int objnum, SString option, byte parts, bool 
 			}
 			else
 			{
-				if (line1->OneSided() != line2->OneSided())
-					continue;
-				
 				Sector *l1front = line1->Right(level)->SecRef(level);
 				Sector *l2front = line2->Right(level)->SecRef(level);
 				Sector *l1back = NULL, *l2back = NULL;


### PR DESCRIPTION
This new command recursively selects connected flats and sidedefs with either the same texture or the same height as the first selected. The default binds are the same as Doom Builder- shift-M1 to select by texture, ctrl-M1 to select by height.
