### PR TITLE
Warp

### DIFF
--- a/src/m_config.cc
+++ b/src/m_config.cc
@@ -616,6 +616,15 @@ static const opt_desc_t options[] =
 		&config::map_scroll_bars
 	},
 
+	{	"teleport_for_test",
+		0,
+        OptType::boolean,
+		OptFlag_preference,
+		"When testing, teleport player to current 3D view position.",
+		NULL,
+		&config::teleport_for_test
+	},
+
 	{	"minimum_drag_pixels",
 		0,
         OptType::integer,

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -38,6 +38,7 @@ extern int default_edit_mode;
 
 extern bool auto_load_recent;
 extern bool begin_maximized;
+extern bool teleport_for_test;
 
 extern bool map_scroll_bars;
 

--- a/src/m_testmap.cc
+++ b/src/m_testmap.cc
@@ -23,12 +23,14 @@
 
 #include "main.h"
 
+#include "m_config.h"
 #include "m_files.h"
 #include "m_loadsave.h"
 #include "w_wad.h"
 
 #include "ui_window.h"
 
+bool config::teleport_for_test = false;
 
 static SString QueryName(const SString &port, const SString &cgame)
 {
@@ -394,6 +396,14 @@ void Instance::CMD_TestMap()
 	SString cmd_buffer = SString::printf("%s %s %s",
 										 CalcEXEName(info).c_str(), GrabWadNames(*this, info).c_str(),
 										 CalcWarpString(*this).c_str());
+
+	if(config::teleport_for_test)
+	{
+		// Append position warp console command, to teleport to the current camera position
+		int warp_x = r_view.x;
+		int warp_y = r_view.y;
+		cmd_buffer = SString::printf("%s \"+warp %d %d\"", cmd_buffer.c_str(), warp_x, warp_y);
+	}
 
 	gLog.printf("Testing map using the following command:\n");
 	gLog.printf("--> %s\n", cmd_buffer.c_str());

--- a/src/ui_prefs.cc
+++ b/src/ui_prefs.cc
@@ -647,6 +647,7 @@ public:
 	Fl_Check_Button *gen_autoload;
 	Fl_Check_Button *gen_maximized;
 	Fl_Check_Button *gen_swapsides;
+	Fl_Check_Button *gen_teleport_for_test;
 
 	/* Keys Tab */
 
@@ -821,7 +822,9 @@ UI_Preferences::UI_Preferences() :
 		}
 		{ gen_swapsides = new Fl_Check_Button(50, 310, 380, 25, " swap upper and lower sidedefs in Linedef panel");
 		}
-		{ gen_maximized = new Fl_Check_Button(50, 340, 380, 25, " maximize the window when Eureka starts");
+		{ gen_teleport_for_test = new Fl_Check_Button(50, 340, 380, 25, " when testing, teleport player to 3D view position (ZDOOM only)");
+		}
+		{ gen_maximized = new Fl_Check_Button(50, 370, 380, 25, " maximize the window when Eureka starts");
 		  // not supported on MacOS X
 		  // (on that platform we should restore last window position, but I don't
 		  //  know how to code that)
@@ -1448,6 +1451,7 @@ void UI_Preferences::LoadValues()
 	gen_autoload   ->value(config::auto_load_recent ? 1 : 0);
 	gen_maximized  ->value(config::begin_maximized  ? 1 : 0);
 	gen_swapsides  ->value(config::swap_sidedefs    ? 1 : 0);
+	gen_teleport_for_test ->value(config::teleport_for_test ? 1 : 0);
 
 	/* Edit Tab */
 
@@ -1595,6 +1599,7 @@ void UI_Preferences::SaveValues()
 
 	config::auto_load_recent  = gen_autoload   ->value() ? true : false;
 	config::begin_maximized   = gen_maximized  ->value() ? true : false;
+	config::teleport_for_test = gen_teleport_for_test ->value() ? true : false;
 	config::swap_sidedefs     = gen_swapsides  ->value() ? true : false;
 
 	/* Edit Tab */


### PR DESCRIPTION
When enabled and using GZDoom to test, this will launch GZDoom with the +warp X Y parameter so you teleport to where Eureka's 3D view is. Very convenient when you're just working on one area.