### PR TITLE
Modifier keys to vary the level of highlighting

### DIFF
--- a/src/ui_canvas.h
+++ b/src/ui_canvas.h
@@ -102,6 +102,9 @@ public:
 	void DrawHighlight(ObjType objtype, int objnum,
 	                   bool skip_lines = false, double dx=0, double dy=0);
 	void DrawHighlightTransform(ObjType objtype, int objnum);
+	v2double_t GetMidpoint(const ObjType objtype, const int objnum);
+	void DrawConnection(const ObjType objtypeCause , const int objnumCause,
+						const ObjType objtypeEffect, const int objnumEffect);
 	void DrawTagged(ObjType objtype, int objnum);
 
 	// returns true if ok, false if box was very small

--- a/test/m_bitvec_test.cpp
+++ b/test/m_bitvec_test.cpp
@@ -47,8 +47,8 @@ TEST(BitVec, SetClearToggle)
     vec.set(100);
 	ASSERT_GE(vec.size(), 100);
 	int lastSize = vec.size();
-    for(int i = 0; i < vec.size(); ++i)
-        ASSERT_EQ(vec.get(i), i == 100);
+	for(int i = 0; i < vec.size(); ++i)
+		ASSERT_EQ(vec.get(i), i == 100);
 
 	vec.set(50);
 	ASSERT_EQ(vec.size(), lastSize);


### PR DESCRIPTION
```
Using 3D camera movement as a model the following modifier keys will affect the level (amount) of highlighting:
  Shift   - Minimal. Currently this means no highlighting.
  Control - Maximal. Draw lines connecting linedefs and sectors that
            are related via a tag.
```

---

As you probably know some level editors show the relationship between linedefs and the tagged sector with a line connecting them. Since you may have already made a design decision to not do that I wanted to share an idea about how it could be opt-in, and how it could be patterned after 3D camera movement.

Since shift results in less camera movement, and control more, I decided to apply that to highlighting as well.

The shift key turns off all highlighting. This can be helpful when the user wants to the the original color of a highlighted or selected item. It can also be helpful to make the highlighted or selected items flash, to make them easier to see.

The control key draws additional highlighting. In particular it draws a line between the tagged items.

I consider this to be a rough draft with a few "TODO"s in it. There are things that I need to understand better, like the way event handling should work. It's more proof of concept.

Here's an example of what it looks like with the control key pressed. The vertical linedef on the right side is a switch that activates the two sectors.

![control-key-example](https://user-images.githubusercontent.com/2380178/202930371-26f454d8-8f00-403c-81f1-25166e394525.jpg)

Also, the whitespace change to `m_bitvec_test.cpp` is because the C++ compiler on one of my Linux systems didn't like the transition from tabs to spaces.