### PR TITLE
removes an erroneous(?) argument from map test on posix

### DIFF
--- a/src/m_testmap.cc
+++ b/src/m_testmap.cc
@@ -505,7 +505,6 @@ static void testMapOnPOSIX(const Instance &inst, const fs::path& portPath)
 	fs::path portName = portPath.filename();
 	SString portPathStorage = portName.u8string();
 	
-	argv.push_back(portPathStorage.get().data());
 	SString argString;
 	for(SString &arg : args)
 	{


### PR DESCRIPTION
compiled master earlier (gentoo), noticed that map testing didn't work (dsda-doom). seems like an extra copy of the executable filename gets prepended to argv. i've nuked the offending line of code.  