### PR TITLE
Two fixes for Linux: compilation and segmentation fault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,9 @@ else()
 endif()
 
 add_subdirectory(src)
+if(UNIX AND NOT APPLE)  # Linux
+    target_include_directories(eurekasrc PRIVATE /usr/include/cairo)
+endif()
 if(APPLE)
     target_link_libraries(eurekasrc PRIVATE eurekamac)
     target_link_libraries(eurekamac PRIVATE eurekasrc)

--- a/src/main.cc
+++ b/src/main.cc
@@ -576,7 +576,7 @@ int Main_key_handler(int event)
 int x11_check_focus_change(void *xevent, void *data)
 {
 	// TODO: get multiple windows
-	if (gInstance->main_win != NULL)
+	if (gInstance->main_win != NULL && xevent != NULL)
 	{
 		const XEvent *xev = (const XEvent *)xevent;
 


### PR DESCRIPTION
This PR includes the two small changes that I needed to make so that eureka compiles and runs well in my linux system (debian testing).

Both problems were present for me with the code downloaded from the `master` branch of the repository, and also when downloading the source of the debian package (with `apt source eureka`, which corresponds to version 2.0.2-1).