### PR TITLE
Add tests for undoable lump changes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 add_executable(
     test_general
     DocumentTest.cpp
+    e_basis_test.cpp
     e_checks_test.cpp
     e_commands_test.cpp
     e_cutpaste_test.cpp

--- a/test/e_basis_test.cpp
+++ b/test/e_basis_test.cpp
@@ -1,0 +1,73 @@
+//  Eureka DOOM Editor
+//
+//  Copyright (C) 2025 Ioan Chera
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//------------------------------------------------------------------------
+
+#include "gtest/gtest.h"
+#include "Document.h"
+#include "Instance.h"
+
+class BasisLumpChangeFixture : public ::testing::TestWithParam<LumpType>
+{
+protected:
+    Instance inst;
+    Document doc{inst};
+
+    std::vector<byte> &lump(LumpType type)
+    {
+        switch(type)
+        {
+        case LumpType::header:
+            return doc.headerData;
+        case LumpType::behavior:
+            return doc.behaviorData;
+        case LumpType::scripts:
+            return doc.scriptsData;
+        }
+        // Should never reach here
+        return doc.headerData;
+    }
+};
+
+TEST_P(BasisLumpChangeFixture, ChangeUndoRedo)
+{
+    LumpType type = GetParam();
+    auto &data = lump(type);
+
+    std::vector<byte> original{1, 2, 3};
+    data = original;
+
+    std::vector<byte> replacement{4, 5};
+    {
+        EditOperation op(doc.basis);
+        op.changeLump(type, std::vector<byte>(replacement));
+    }
+
+    EXPECT_EQ(data, replacement);
+
+    ASSERT_TRUE(doc.basis.undo());
+    EXPECT_EQ(data, original);
+
+    ASSERT_TRUE(doc.basis.redo());
+    EXPECT_EQ(data, replacement);
+
+    ASSERT_TRUE(doc.basis.undo());
+    EXPECT_EQ(data, original);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BasisLumpChanges,
+    BasisLumpChangeFixture,
+    ::testing::Values(LumpType::header, LumpType::behavior, LumpType::scripts));
+

--- a/test/e_basis_test.cpp
+++ b/test/e_basis_test.cpp
@@ -64,6 +64,17 @@ TEST_P(BasisLumpChangeFixture, ChangeUndoRedo)
 
     ASSERT_TRUE(doc.basis.undo());
     EXPECT_EQ(data, original);
+
+	// Now change something to see that redo becomes unavailable
+	{
+		EditOperation op(doc.basis);
+		op.changeLump(type, std::vector<byte>{6, 7});
+	}
+	ASSERT_FALSE(doc.basis.redo());
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_EQ(data, original);
+
+	ASSERT_FALSE(doc.basis.undo());
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Summary
- add unit tests for Basis lump change undo/redo behavior
- integrate e_basis_test.cpp with test_general build

## Testing
- `cmake --build build --target test_general`
- `./build/test/test_general`

------
https://chatgpt.com/codex/tasks/task_e_68b5700690bc8325961e42e7a9854929