### PR TITLE
Show Google Tests executed in CI logs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,4 +35,4 @@ jobs:
         make -C build -j$(nproc)
     - name: Test
       run: |
-        ctest --test-dir build --output-on-failure
+        ctest --test-dir build --output-on-failure --verbose

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Release --parallel
       - name: Test
-        run: ctest --test-dir build --output-on-failure -C Release
+        run: ctest --test-dir build --output-on-failure -C Release --verbose
       - name: Archive
         run: |
           Copy-Item AUTHORS.md,GPL.txt,README.txt,TODO.txt build\Release


### PR DESCRIPTION
## Summary
- run ctest with `--verbose` in CI so Google Test names appear even on success

## Testing
- `ctest --test-dir build --output-on-failure --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68b57392b9888325a57b0e1a73e27f3e