### PR TITLE
Encapsulate MadeChanges flag and refine tests

### DIFF
--- a/src/Document.h
+++ b/src/Document.h
@@ -41,8 +41,8 @@ struct Document
 {
 private:
 	Instance &inst;	// make this private because we don't want to access it from Document
-        bool mMadeChanges = false;
-        friend class Basis;
+	bool mMadeChanges = false;
+	friend class Basis;
 public:
 
 	std::vector<std::shared_ptr<Thing>> things;
@@ -54,10 +54,10 @@ public:
 	std::vector<byte> headerData;
 	std::vector<byte> behaviorData;
 	std::vector<byte> scriptsData;
-	
+
 	v2double_t Map_bound1 = { 32767, 32767 };	/* minimum XY value of map */
 	v2double_t Map_bound2 = { -32767, -32767 };	/* maximum XY value of map */
-	
+
 
 	Basis basis;
 	ChecksModule checks;
@@ -71,42 +71,42 @@ public:
 	linemod(*this), vertmod(*this), secmod(*this), objects(*this)
 	{
 	}
-	
-	Document(Document &&other) noexcept : inst(other.inst), basis(*this), checks(*this), hover(*this), linemod(*this), vertmod(*this), secmod(*this), objects(*this) 
+
+	Document(Document &&other) noexcept : inst(other.inst), basis(*this), checks(*this), hover(*this), linemod(*this), vertmod(*this), secmod(*this), objects(*this)
 	{
 		*this = std::move(other);
 	}
-	
-        Document &operator = (Document &&other) noexcept
-        {
-                things = std::move(other.things);
-                vertices = std::move(other.vertices);
-                sectors = std::move(other.sectors);
-                sidedefs = std::move(other.sidedefs);
-                linedefs = std::move(other.linedefs);
-                headerData = std::move(other.headerData);
-                behaviorData = std::move(other.behaviorData);
-                scriptsData = std::move(other.scriptsData);
-                Map_bound1 = other.Map_bound1;
-                Map_bound2 = other.Map_bound2;
-                mMadeChanges = other.mMadeChanges;
-                // TODO: basis
-                basis = std::move(other.basis);
-                return *this;
-        }
 
-        bool hasChanges() const noexcept { return mMadeChanges; }
-        void markSaved() { mMadeChanges = false; basis.setSavedStack(); }
+	Document &operator = (Document &&other) noexcept
+	{
+		things = std::move(other.things);
+		vertices = std::move(other.vertices);
+		sectors = std::move(other.sectors);
+		sidedefs = std::move(other.sidedefs);
+		linedefs = std::move(other.linedefs);
+		headerData = std::move(other.headerData);
+		behaviorData = std::move(other.behaviorData);
+		scriptsData = std::move(other.scriptsData);
+		Map_bound1 = other.Map_bound1;
+		Map_bound2 = other.Map_bound2;
+		mMadeChanges = other.mMadeChanges;
+		// TODO: basis
+		basis = std::move(other.basis);
+		return *this;
+	}
+
+	bool hasChanges() const noexcept { return mMadeChanges; }
+	void markSaved() { mMadeChanges = false; basis.setSavedStack(); }
 
 private:
-        void setMadeChanges(bool val) { mMadeChanges = val; }
+	void setMadeChanges(bool val) { mMadeChanges = val; }
 
 public:
 
-        //
-        // Count map objects
-        //
-        int numThings() const noexcept
+	//
+	// Count map objects
+	//
+	int numThings() const noexcept
 	{
 		return static_cast<int>(things.size());
 	}
@@ -176,7 +176,7 @@ public:
 	bool isSelfRef(const LineDef &line) const;
 	bool isHorizontal(const LineDef &line) const;
 	bool isVertical(const LineDef &line) const;
-	
+
 	void LoadHeader(int loading_level, const Wad_file &load_wad);
 	void LoadThings(int loading_level, const Wad_file *load_wad);
 	void LoadThings_Hexen(int loading_level, const Wad_file *load_wad);
@@ -187,9 +187,9 @@ public:
 	void LoadSideDefs(int loading_level, const Wad_file *load_wad, const ConfigData &config, BadCount &bad);
 	void LoadBehavior(int loading_level, const Wad_file *load_wad);
 	void LoadScripts(int loading_level, const Wad_file *load_wad);
-	
+
 	void RemoveUnusedVerticesAtEnd();
-	
+
 	void CreateFallbackVertices();
 	void CreateFallbackSideDef(const ConfigData &config);
 	void CreateFallbackSector(const ConfigData &config);
@@ -197,7 +197,7 @@ public:
 	void ValidateSidedefRefs(LineDef &ld, int num, const ConfigData &config, BadCount &bad);
 	void ValidateSectorRef(SideDef &sd, int num, const ConfigData &config, BadCount &bad);
 	void ValidateLevel_UDMF(const ConfigData &config, BadCount &bad);
-	
+
 	void CalculateLevelBounds() noexcept;
 	void UpdateLevelBounds(int start_vert) noexcept;
 
@@ -211,7 +211,7 @@ public:
 	void SaveSectors(Wad_file& wad) const;
 	void SaveBehavior(Wad_file& wad) const;
 	void SaveScripts(Wad_file& wad) const;
-	
+
 	void clear();
 
 	bool Main_ConfirmQuit(const char* action) const;

--- a/src/Document.h
+++ b/src/Document.h
@@ -41,6 +41,8 @@ struct Document
 {
 private:
 	Instance &inst;	// make this private because we don't want to access it from Document
+        bool mMadeChanges = false;
+        friend class Basis;
 public:
 
 	std::vector<std::shared_ptr<Thing>> things;
@@ -56,7 +58,6 @@ public:
 	v2double_t Map_bound1 = { 32767, 32767 };	/* minimum XY value of map */
 	v2double_t Map_bound2 = { -32767, -32767 };	/* maximum XY value of map */
 	
-	bool MadeChanges = false;
 
 	Basis basis;
 	ChecksModule checks;
@@ -76,28 +77,36 @@ public:
 		*this = std::move(other);
 	}
 	
-	Document &operator = (Document &&other) noexcept
-	{
-		things = std::move(other.things);
-		vertices = std::move(other.vertices);
-		sectors = std::move(other.sectors);
-		sidedefs = std::move(other.sidedefs);
-		linedefs = std::move(other.linedefs);
-		headerData = std::move(other.headerData);
-		behaviorData = std::move(other.behaviorData);
-		scriptsData = std::move(other.scriptsData);
-		Map_bound1 = other.Map_bound1;
-		Map_bound2 = other.Map_bound2;
-		MadeChanges = other.MadeChanges;
-		// TODO: basis
-		basis = std::move(other.basis);
-		return *this;
-	}
+        Document &operator = (Document &&other) noexcept
+        {
+                things = std::move(other.things);
+                vertices = std::move(other.vertices);
+                sectors = std::move(other.sectors);
+                sidedefs = std::move(other.sidedefs);
+                linedefs = std::move(other.linedefs);
+                headerData = std::move(other.headerData);
+                behaviorData = std::move(other.behaviorData);
+                scriptsData = std::move(other.scriptsData);
+                Map_bound1 = other.Map_bound1;
+                Map_bound2 = other.Map_bound2;
+                mMadeChanges = other.mMadeChanges;
+                // TODO: basis
+                basis = std::move(other.basis);
+                return *this;
+        }
 
-	//
-	// Count map objects
-	//
-	int numThings() const noexcept
+        bool hasChanges() const noexcept { return mMadeChanges; }
+        void markSaved() { mMadeChanges = false; basis.setSavedStack(); }
+
+private:
+        void setMadeChanges(bool val) { mMadeChanges = val; }
+
+public:
+
+        //
+        // Count map objects
+        //
+        int numThings() const noexcept
 	{
 		return static_cast<int>(things.size());
 	}

--- a/src/e_basis.cc
+++ b/src/e_basis.cc
@@ -1030,7 +1030,7 @@ void Basis::doProcessChangeStatus() const
 	if(mDidMakeChanges)
 	{
 		// TODO: the other modules
-		doc.MadeChanges = mSavedStack != mUndoHistory;
+                doc.setMadeChanges(mSavedStack != mUndoHistory);
 		inst.RedrawMap();
 	}
 

--- a/src/e_basis.cc
+++ b/src/e_basis.cc
@@ -212,7 +212,7 @@ void Basis::setMessage(EUR_FORMAT_STRING(const char *format), ...)
 	SString message = SString::vprintf(format, arg_ptr);
 	mCurrentGroup.setMessage(message);
 	va_end(arg_ptr);
-	
+
 	mCurrentGroup.setMenuName(makeInfinitive(message));
 }
 
@@ -454,7 +454,7 @@ void Basis::changeLump(LumpType lumpType, std::vector<byte> &&newData)
 	op.action = EditType::lump_change;
 	op.lumptype = lumpType;
 	op.lumpData = std::move(newData);
-	
+
 	mCurrentGroup.addApply(std::move(op), *this);
 }
 
@@ -506,7 +506,7 @@ bool Basis::redo()
 	mRedoFuture.pop();
 
 	inst.Status_Set("Redo: %s", grp.getMessage().c_str());
-	
+
 	if(inst.main_win)
 	{
 		Fl_Sys_Menu_Bar *bar = inst.main_win->menu_bar;
@@ -531,13 +531,13 @@ void Basis::clear()
 		mUndoHistory.pop_back();
 	while(!mRedoFuture.empty())
 		mRedoFuture.pop();
-	
+
 	if(inst.main_win)
 	{
 		menu::setUndoDetail(inst.main_win->menu_bar, "");
 		menu::setRedoDetail(inst.main_win->menu_bar, "");
 	}
-	
+
 	// Note: we don't clear the string table, since there can be
 	//       string references in the clipboard.
 
@@ -1030,7 +1030,7 @@ void Basis::doProcessChangeStatus() const
 	if(mDidMakeChanges)
 	{
 		// TODO: the other modules
-                doc.setMadeChanges(mSavedStack != mUndoHistory);
+		doc.setMadeChanges(mSavedStack != mUndoHistory);
 		inst.RedrawMap();
 	}
 

--- a/src/e_main.cc
+++ b/src/e_main.cc
@@ -85,8 +85,8 @@ void Instance::zoom_fit()
 
 void Instance::ZoomWholeMap()
 {
-        if (level.hasChanges())
-                level.CalculateLevelBounds();
+	if (level.hasChanges())
+		level.CalculateLevelBounds();
 
 	zoom_fit();
 
@@ -153,19 +153,19 @@ static void UpdatePanel(const Instance &inst)
 			case ObjType::things:
 				inst.main_win->thing_box->SetObj(obj_idx, obj_count);
 				break;
-				
+
 			case ObjType::linedefs:
 				inst.main_win->line_box->SetObj(obj_idx, obj_count);
 				break;
-				
+
 			case ObjType::sectors:
 				inst.main_win->sec_box->SetObj(obj_idx, obj_count);
 				break;
-				
+
 			case ObjType::vertices:
 				inst.main_win->vert_box->SetObj(obj_idx, obj_count);
 				break;
-				
+
 			default: break;
 		}
 	}
@@ -938,7 +938,7 @@ void Instance::Selection_Push()
 
 	// OK copy it
 
-	
+
 	last_Sel.emplace(edit.Selected->what_type(), true);
 
 	last_Sel->merge(*edit.Selected);
@@ -1260,7 +1260,7 @@ void Instance::Editor_Init()
 
 	grid.Init();
 
-        level.markSaved();
+	level.markSaved();
 
 	  Editor_RegisterCommands();
 	Render3D_RegisterCommands();

--- a/src/e_main.cc
+++ b/src/e_main.cc
@@ -85,8 +85,8 @@ void Instance::zoom_fit()
 
 void Instance::ZoomWholeMap()
 {
-	if (level.MadeChanges)
-		level.CalculateLevelBounds();
+        if (level.hasChanges())
+                level.CalculateLevelBounds();
 
 	zoom_fit();
 
@@ -1260,7 +1260,7 @@ void Instance::Editor_Init()
 
 	grid.Init();
 
-	level.MadeChanges = false;
+        level.markSaved();
 
 	  Editor_RegisterCommands();
 	Render3D_RegisterCommands();

--- a/src/m_loadsave.cc
+++ b/src/m_loadsave.cc
@@ -999,7 +999,7 @@ NewDocument Instance::openDocument(const LoadingData &inLoading, const Wad_file 
 	doc.RemoveUnusedVerticesAtEnd();
 	doc.checks.sidedefsUnpack(true);
 	doc.CalculateLevelBounds();
-        doc.markSaved();
+	doc.markSaved();
 
 	return newdoc;
 }

--- a/src/m_loadsave.cc
+++ b/src/m_loadsave.cc
@@ -999,7 +999,7 @@ NewDocument Instance::openDocument(const LoadingData &inLoading, const Wad_file 
 	doc.RemoveUnusedVerticesAtEnd();
 	doc.checks.sidedefsUnpack(true);
 	doc.CalculateLevelBounds();
-	doc.MadeChanges = false;
+        doc.markSaved();
 
 	return newdoc;
 }
@@ -1696,8 +1696,7 @@ void Instance::ConfirmLevelSaveSuccess(const LoadingData &loading, const Wad_fil
 		M_SaveUserState();
 	}
 
-	this->level.MadeChanges = false;
-	this->level.basis.setSavedStack();
+        this->level.markSaved();
 }
 
 //

--- a/src/m_nodes.cc
+++ b/src/m_nodes.cc
@@ -382,7 +382,7 @@ void Instance::CMD_BuildAllNodes()
 		return;
 	}
 
-	if (level.MadeChanges)
+        if (level.hasChanges())
 	{
 		if (DLG_Confirm({ "Cancel", "&Save" },
 			"You have unsaved changes, do you want to save them now "

--- a/src/m_nodes.cc
+++ b/src/m_nodes.cc
@@ -285,7 +285,7 @@ build_result_e Instance::BuildAllNodes(nodebuildinfo_t *info)
 		try
 		{
 			NewDocument newdoc = openDocument(loaded, *wad.master.editWad(), n);
-			
+
 			ret = AJBSP_BuildLevel(info, n, *this, newdoc.doc, newdoc.loading, *wad.master.editWad());
 		}
 		catch(const std::runtime_error &e)
@@ -311,7 +311,7 @@ build_result_e Instance::BuildAllNodes(nodebuildinfo_t *info)
 			nb_info->cancelled = true;
 		}
 	}
-	
+
 	try
 	{
 		wad.master.editWad()->writeToDisk();
@@ -382,7 +382,7 @@ void Instance::CMD_BuildAllNodes()
 		return;
 	}
 
-        if (level.hasChanges())
+	if (level.hasChanges())
 	{
 		if (DLG_Confirm({ "Cancel", "&Save" },
 			"You have unsaved changes, do you want to save them now "

--- a/src/m_testmap.cc
+++ b/src/m_testmap.cc
@@ -583,7 +583,7 @@ void Instance::CMD_TestMap()
 {
 	try
 	{
-		if (level.MadeChanges)
+                if (level.hasChanges())
 		{
 			if (DLG_Confirm({ "Cancel", "&Save" },
 				"You have unsaved changes, do you want to save them now "

--- a/src/m_testmap.cc
+++ b/src/m_testmap.cc
@@ -90,27 +90,27 @@ static bool isMacOSAppBundle(const fs::path &path)
 		return false;
 	}
 	CFURLRef url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, pathString, kCFURLPOSIXPathStyle, true);
-	
+
 	CFRelease(pathString);
 	if(!url)
 	{
 		gLog.printf("ERROR: Failed allocating macOS app bundle CF URL: %s\n", path.u8string().c_str());
-		
+
 		return false;
 	}
-	
+
 	CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, url);
 	CFRelease(url);
 	if(!bundle)
 	{
 		gLog.printf("Could not load, or invalid macOS app CF bundle: %s\n", path.u8string().c_str());
-		
+
 		return false;
 	}
-	
+
 	CFDictionaryRef infoDict = CFBundleGetInfoDictionary(bundle);
 	CFRelease(bundle);
-	
+
 	return !!infoDict;
 #else
 	return false;
@@ -138,7 +138,7 @@ public:
 	static const int BOTTOM_BUTTON_SPACING = 45;
 
 	Fl_Output *exe_display;
-	
+
 	Fl_Button *ok_but;
 	Fl_Button *cancel_but;
 
@@ -481,10 +481,10 @@ static void testMapOnMacBundle(const Instance &inst, const fs::path& portPath)
 	std::vector<SString> args;
 	GrabWadNamesArgs(inst, args);
 	CalcWarpString(inst.loaded.levelName, args);
-	
+
 	SString argString = SString("/usr/bin/open -a ") + SString(portPath.u8string()).spaceEscape(true) + " --args " + inst.loaded.testingCommandLine + " " + buildArgString(args, true);
 	logArgs(argString);
-	
+
 	int ret = system(argString.c_str());
 	if(ret == -1)
 	{
@@ -504,7 +504,7 @@ static void testMapOnPOSIX(const Instance &inst, const fs::path& portPath)
 	while(parse.getNext(arg))
 		args.push_back(arg);
 	args.insert(args.begin(), portPath.u8string());
-	
+
 	std::vector<char *> argv;
 	argv.reserve(args.size() + 2);
 	fs::path portName = portPath.filename();
@@ -533,11 +533,11 @@ static void testMapOnPOSIX(const Instance &inst, const fs::path& portPath)
 		{
 			DirChangeContext dirChangeContext(FilenameGetPath(portPath));
 			execvp(portPath.u8string().c_str(), argv.data());
-			
+
 			// on failure
 			int err = errno;
 			gLog.printf("--> Failed starting %s: %s\n", portName.u8string().c_str(), GetErrorMessage(err).c_str());
-			
+
 			_exit(err);
 		}
 		catch(const std::exception &e)
@@ -583,7 +583,7 @@ void Instance::CMD_TestMap()
 {
 	try
 	{
-                if (level.hasChanges())
+		if (level.hasChanges())
 		{
 			if (DLG_Confirm({ "Cancel", "&Save" },
 				"You have unsaved changes, do you want to save them now "
@@ -634,14 +634,14 @@ void Instance::CMD_TestMap()
 			main_win->redraw();
 		Fl::wait(0.1);
 		Fl::wait(0.1);
-		
+
 	}
 	catch(const std::runtime_error &e)
 	{
 		Status_Set("Failed testing map");
 		DLG_ShowError(false, "Could not start map for testing: %s", e.what());
 	}
-	
+
 }
 
 namespace testmap

--- a/src/main.cc
+++ b/src/main.cc
@@ -784,8 +784,8 @@ void Main_Quit()
 // used for 'New Map' / 'Open Map' functions too
 bool Document::Main_ConfirmQuit(const char *action) const
 {
-	if (! MadeChanges)
-		return true;
+        if (! hasChanges())
+                return true;
 
 	SString secondButton = SString::printf("&%s", action);
 	// convert action string like "open a new map" to a simple "Open"
@@ -884,7 +884,7 @@ void Main_Loop()
 		// TODO: handle these in a better way
 
 		// TODO: HANDLE ALL INSTANCES
-		gInstance->main_win->UpdateTitle(gInstance->level.MadeChanges ? '*' : 0);
+                gInstance->main_win->UpdateTitle(gInstance->level.hasChanges() ? '*' : 0);
 
 		gInstance->main_win->scroll->UpdateBounds();
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -784,8 +784,8 @@ void Main_Quit()
 // used for 'New Map' / 'Open Map' functions too
 bool Document::Main_ConfirmQuit(const char *action) const
 {
-        if (! hasChanges())
-                return true;
+	if (! hasChanges())
+		return true;
 
 	SString secondButton = SString::printf("&%s", action);
 	// convert action string like "open a new map" to a simple "Open"
@@ -884,7 +884,7 @@ void Main_Loop()
 		// TODO: handle these in a better way
 
 		// TODO: HANDLE ALL INSTANCES
-                gInstance->main_win->UpdateTitle(gInstance->level.hasChanges() ? '*' : 0);
+		gInstance->main_win->UpdateTitle(gInstance->level.hasChanges() ? '*' : 0);
 
 		gInstance->main_win->scroll->UpdateBounds();
 

--- a/test/e_basis_test.cpp
+++ b/test/e_basis_test.cpp
@@ -21,49 +21,49 @@
 class BasisLumpChangeFixture : public ::testing::TestWithParam<LumpType>
 {
 protected:
-    Instance inst;
-    Document doc{inst};
+	Instance inst;
+	Document doc{inst};
 
-    std::vector<byte> &lump(LumpType type)
-    {
-        switch(type)
-        {
-        case LumpType::header:
-            return doc.headerData;
-        case LumpType::behavior:
-            return doc.behaviorData;
-        case LumpType::scripts:
-            return doc.scriptsData;
-        }
-        // Should never reach here
-        return doc.headerData;
-    }
+	std::vector<byte> &lump(LumpType type)
+	{
+		switch(type)
+		{
+		case LumpType::header:
+			return doc.headerData;
+		case LumpType::behavior:
+			return doc.behaviorData;
+		case LumpType::scripts:
+			return doc.scriptsData;
+		}
+		// Should never reach here
+		return doc.headerData;
+	}
 };
 
 TEST_P(BasisLumpChangeFixture, ChangeUndoRedo)
 {
-    LumpType type = GetParam();
-    auto &data = lump(type);
+	LumpType type = GetParam();
+	auto &data = lump(type);
 
-    std::vector<byte> original{1, 2, 3};
-    data = original;
+	std::vector<byte> original{1, 2, 3};
+	data = original;
 
-    std::vector<byte> replacement{4, 5};
-    {
-        EditOperation op(doc.basis);
-        op.changeLump(type, std::vector<byte>(replacement));
-    }
+	std::vector<byte> replacement{4, 5};
+	{
+		EditOperation op(doc.basis);
+		op.changeLump(type, std::vector<byte>(replacement));
+	}
 
-    EXPECT_EQ(data, replacement);
+	EXPECT_EQ(data, replacement);
 
-    ASSERT_TRUE(doc.basis.undo());
-    EXPECT_EQ(data, original);
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_EQ(data, original);
 
-    ASSERT_TRUE(doc.basis.redo());
-    EXPECT_EQ(data, replacement);
+	ASSERT_TRUE(doc.basis.redo());
+	EXPECT_EQ(data, replacement);
 
-    ASSERT_TRUE(doc.basis.undo());
-    EXPECT_EQ(data, original);
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_EQ(data, original);
 
 	// Now change something to see that redo becomes unavailable
 	{
@@ -78,74 +78,74 @@ TEST_P(BasisLumpChangeFixture, ChangeUndoRedo)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    BasisLumpChanges,
-    BasisLumpChangeFixture,
-    ::testing::Values(LumpType::header, LumpType::behavior, LumpType::scripts));
+	BasisLumpChanges,
+	BasisLumpChangeFixture,
+	::testing::Values(LumpType::header, LumpType::behavior, LumpType::scripts));
 
 class BasisChangeStatusFixture : public ::testing::Test
 {
 protected:
-    Instance inst;
-    Document doc{inst};
+	Instance inst;
+	Document doc{inst};
 
-    void changeHeader(const std::vector<byte> &data)
-    {
-        EditOperation op(doc.basis);
-        op.changeLump(LumpType::header, std::vector<byte>(data));
-    }
+	void changeHeader(const std::vector<byte> &data)
+	{
+		EditOperation op(doc.basis);
+		op.changeLump(LumpType::header, std::vector<byte>(data));
+	}
 };
 
 // Saving should update the saved stack and clear MadeChanges
 TEST_F(BasisChangeStatusFixture, SavingResetsMadeChanges)
 {
-    doc.headerData = {1};
-    changeHeader({2});
-    EXPECT_TRUE(doc.hasChanges());
+	doc.headerData = {1};
+	changeHeader({2});
+	EXPECT_TRUE(doc.hasChanges());
 
-    doc.markSaved();
-    EXPECT_FALSE(doc.hasChanges());
+	doc.markSaved();
+	EXPECT_FALSE(doc.hasChanges());
 }
 
 // Undoing and redoing toggles MadeChanges depending on the saved stack
 TEST_F(BasisChangeStatusFixture, UndoRedoTogglesMadeChanges)
 {
-    doc.headerData = {1};
+	doc.headerData = {1};
 
-    changeHeader({2});
-    doc.markSaved();
+	changeHeader({2});
+	doc.markSaved();
 
-    changeHeader({3});
-    EXPECT_TRUE(doc.hasChanges());
+	changeHeader({3});
+	EXPECT_TRUE(doc.hasChanges());
 
-    ASSERT_TRUE(doc.basis.undo());
-    EXPECT_FALSE(doc.hasChanges());
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_FALSE(doc.hasChanges());
 
-    ASSERT_TRUE(doc.basis.undo());
-    EXPECT_TRUE(doc.hasChanges());
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_TRUE(doc.hasChanges());
 
-    ASSERT_TRUE(doc.basis.redo());
-    EXPECT_FALSE(doc.hasChanges());
+	ASSERT_TRUE(doc.basis.redo());
+	EXPECT_FALSE(doc.hasChanges());
 
-    ASSERT_TRUE(doc.basis.redo());
-    EXPECT_TRUE(doc.hasChanges());
+	ASSERT_TRUE(doc.basis.redo());
+	EXPECT_TRUE(doc.hasChanges());
 }
 
 // Repeating a redo operation manually can clear the MadeChanges flag
 TEST_F(BasisChangeStatusFixture, ManualRedoActionClearsMadeChanges)
 {
-    doc.headerData = {1};
+	doc.headerData = {1};
 
-    changeHeader({2});
-    changeHeader({3});
-    doc.markSaved();
+	changeHeader({2});
+	changeHeader({3});
+	doc.markSaved();
 
-    ASSERT_TRUE(doc.basis.undo());
-    EXPECT_TRUE(doc.hasChanges());
+	ASSERT_TRUE(doc.basis.undo());
+	EXPECT_TRUE(doc.hasChanges());
 
-    changeHeader({3});
-    EXPECT_FALSE(doc.hasChanges());
+	changeHeader({3});
+	EXPECT_FALSE(doc.hasChanges());
 
-    changeHeader({4});
-    EXPECT_TRUE(doc.hasChanges());
+	changeHeader({4});
+	EXPECT_TRUE(doc.hasChanges());
 }
 


### PR DESCRIPTION
## Summary
- encapsulate change tracking with `hasChanges` and `markSaved`
- update Basis and save/load paths to use the new API
- revise tests to exercise `markSaved` and `hasChanges`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b58853d0f483258de32be30cef6b72