### PR TITLE
Add cross-platform redo shortcuts

### DIFF
--- a/bindings.cfg
+++ b/bindings.cfg
@@ -189,6 +189,8 @@ general	BS	Delete
 general	SHIFT-DEL	Delete	/keep
 general	SHIFT-BS	Delete	/keep
 
+general	CMD-y	Redo
+general	CMD-Z	Redo
 general	d	Disconnect
 general	m	Merge
 general	q	Quantize

--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -1290,14 +1290,20 @@ static bool canShowUpOnMenu(keycode_t code)
 // Finds key code for given command name
 //
 bool findKeyCodeForCommandName(const char *command, const char *params[MAX_EXEC_PARAM],
-							   keycode_t *code)
+                                                            keycode_t *code)
 {
     assert(!!code);
     *code = UINT_MAX;
+    bool preferRedo = (y_stricmp(command, "Redo") == 0);
+#if defined(_WIN32)
+    keycode_t preferredRedo = EMOD_COMMAND | 'y';
+#else
+    keycode_t preferredRedo = EMOD_COMMAND | EMOD_SHIFT | 'z';
+#endif
     for(const key_binding_t &binding : global::all_bindings)
-	{
-		if(y_stricmp(binding.cmd->name, command))
-			continue;
+        {
+                if(y_stricmp(binding.cmd->name, command))
+                        continue;
 
 		bool skip = false;
 		for(int i = 0; i < MAX_EXEC_PARAM; ++i)
@@ -1315,14 +1321,19 @@ bool findKeyCodeForCommandName(const char *command, const char *params[MAX_EXEC_
 				break;
 			}
 		}
-		if(skip)
-			continue;
+                if(skip)
+                        continue;
+        if(preferRedo && binding.key == preferredRedo && canShowUpOnMenu(binding.key))
+        {
+            *code = binding.key;
+            return true;
+        }
         if(canShowUpOnMenu(binding.key) && binding.key < *code)
             *code = binding.key;
         // Continue looking until we find the lowest numbered key code. That is the smallest ASCII
         // character with no shortcut keys
-	}
-	return *code < UINT_MAX;
+        }
+        return *code < UINT_MAX;
 }
 
 //--- editor settings ---

--- a/src/ui_menu.cc
+++ b/src/ui_menu.cc
@@ -558,8 +558,12 @@ static Fl_Menu_Item menu_items[] =
 
 	{ "&Edit", 0, 0, 0, FL_SUBMENU },
 
-		{ "&Undo",   FL_COMMAND + 'z',  FCAL edit_do_undo },
-		{ "&Redo",   FL_COMMAND + 'y',  FCAL edit_do_redo },
+                { "&Undo",   FL_COMMAND + 'z',  FCAL edit_do_undo },
+#if defined(_WIN32)
+                { "&Redo",   FL_COMMAND + 'y',  FCAL edit_do_redo },
+#else
+                { "&Redo",   FL_COMMAND + FL_SHIFT + 'z',  FCAL edit_do_redo },
+#endif
 
 		{ "", 0, 0, 0, FL_MENU_DIVIDER|FL_MENU_INACTIVE },
 


### PR DESCRIPTION
## Summary
- Support both Cmd/Ctrl+Y and Cmd/Ctrl+Shift+Z for Redo in default key bindings
- Show OS-specific Redo shortcut in the Edit menu
- Prefer platform-specific Redo keys when updating menu shortcuts

## Testing
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b5f579c7ec8325b68d92f84558602d