### PR TITLE
Use column-based key binding list

### DIFF
--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -314,18 +314,6 @@ static SString ModName_Dash(keycode_t mod)
 }
 
 
-static SString ModName_Space(keycode_t mod)
-{
-	SString result = ModName_Dash(mod);
-	if(!result.empty() && result.back() == '-')
-		result.back() = ' ';
-#ifdef __APPLE__
-	if(result == "META ")
-		return "CTRL ";
-#endif
-	return result;
-}
-
 namespace keys
 {
 SString toString(keycode_t key)
@@ -833,30 +821,31 @@ SString stringForFunc(const key_binding_t &bind)
 
 const char * stringForBinding(const key_binding_t& bind, bool changing_key)
 {
-	static char buffer[600];
+        static char buffer[600];
 
-	// we prefer the UI to say "3D view" instead of "render"
-	const char *ctx_name = M_KeyContextString(bind.context);
-	if (y_stricmp(ctx_name, "render") == 0)
-		ctx_name = "3D view";
+        // we prefer the UI to say "3D view" instead of "render"
+        const char *ctx_name = M_KeyContextString(bind.context);
+        if (y_stricmp(ctx_name, "render") == 0)
+                ctx_name = "3D view";
 
-	// display SHIFT + letter as an uppercase letter
-	keycode_t tempk = bind.key;
-	if ((tempk & EMOD_ALL_MASK) == EMOD_SHIFT &&
-		(tempk & FL_KEY_MASK)  <  127 &&
-		isalpha(tempk & FL_KEY_MASK))
-	{
-		tempk = toupper(tempk & FL_KEY_MASK);
-	}
+        // display SHIFT + letter as an uppercase letter
+        keycode_t tempk = bind.key;
+        if ((tempk & EMOD_ALL_MASK) == EMOD_SHIFT &&
+                (tempk & FL_KEY_MASK)  <  127 &&
+                isalpha(tempk & FL_KEY_MASK))
+        {
+                tempk = toupper(tempk & FL_KEY_MASK);
+        }
 
-	snprintf(buffer, sizeof(buffer), "%s%6.6s%-10.10s %-9.9s %.32s",
-			 bind.is_duplicate ? "@C1" : "",
-			 changing_key ? "<?"     : ModName_Space(tempk).c_str(),
-			 changing_key ? "\077?>" : BareKeyName(tempk & FL_KEY_MASK).c_str(),
-			 ctx_name,
-			 stringForFunc(bind).c_str() );
+        SString key_str = changing_key ? SString("<?>") : toString(tempk);
 
-	return buffer;
+        snprintf(buffer, sizeof(buffer), "%s%s\t%s\t%s",
+                         bind.is_duplicate ? "@C1" : "",
+                         key_str.c_str(),
+                         ctx_name,
+                         stringForFunc(bind).c_str() );
+
+        return buffer;
 }
 }
 

--- a/src/ui_prefs.cc
+++ b/src/ui_prefs.cc
@@ -861,10 +861,12 @@ UI_Preferences::UI_Preferences(const opt_desc_t *options) :
 		  key_func->align(Fl_Align(FL_ALIGN_INSIDE));
 		  key_func->callback((Fl_Callback*)sort_key_callback, this);
 		}
-		{ key_list = new Fl_Hold_Browser(20, 115, 442, 308);
-		  key_list->textfont(FL_COURIER);
-		  key_list->has_scrollbar(Fl_Browser_::VERTICAL);
-		}
+                { key_list = new Fl_Hold_Browser(20, 115, 442, 308);
+                  key_list->has_scrollbar(Fl_Browser_::VERTICAL);
+                  static int widths[] = {125, 75, 205, 0};
+                  key_list->column_widths(widths);
+                  key_list->column_char('\t');
+                }
 		{ key_add = new Fl_Button(480, 155, 85, 30, "&Add");
 		  key_add->callback((Fl_Callback*)edit_key_callback, this);
 		}

--- a/test/m_keys_test.cpp
+++ b/test/m_keys_test.cpp
@@ -20,36 +20,35 @@
 
 struct KeyMapping
 {
-	keycode_t code;
-	const char *dashString;
-	const char *spaceString;
+        keycode_t code;
+        const char *dashString;
 };
 
 // NOTE: keep the old names in the dashed names for backward compatibility
 static const KeyMapping testKeyCombos[] =
 {
-	{EMOD_SHIFT | 'k', "K",                     "      K         "},
-	{static_cast<keycode_t>(EMOD_COMMAND) | 'j',
+        {EMOD_SHIFT | 'k', "K"},
+        {static_cast<keycode_t>(EMOD_COMMAND) | 'j',
 #ifdef __APPLE__
-		"CMD-j",                                "  CMD j         "
+                "CMD-j"
 #else
-		"CTRL-j",                               " CTRL j         "
+                "CTRL-j"
 #endif
-	},
-	{static_cast<keycode_t>(EMOD_META) | 'm',
+        },
+        {static_cast<keycode_t>(EMOD_META) | 'm',
 #ifdef __APPLE__
-		"META-m",                 " CTRL m         "
+                "META-m"
 #else
-		"META-m",                 " META m         "
+                "META-m"
 #endif
-	},
-	{EMOD_ALT | 'a', "ALT-a",                   "  ALT a         "},
-	{EMOD_ALT | (FL_Button + 3), "ALT-MOUSE3",  "  ALT MOUSE3    "},
-	{EMOD_ALT | FL_Volume_Down, "ALT-VOL_DOWN", "  ALT VOL_DOWN  "},
-	{EMOD_SHIFT | '5', "SHIFT-5",               "SHIFT 5         "},
-	{EMOD_SHIFT | '"', "SHIFT-DBLQUOTE",        "SHIFT DBLQUOTE  "},
-	{EMOD_SHIFT | (FL_F + 4), "SHIFT-F4",       "SHIFT F4        "},
-	{FL_SCROLL_LOCK | 's', "LAX-s",             "  LAX s         "},
+        },
+        {EMOD_ALT | 'a', "ALT-a"},
+        {EMOD_ALT | (FL_Button + 3), "ALT-MOUSE3"},
+        {EMOD_ALT | FL_Volume_Down, "ALT-VOL_DOWN"},
+        {EMOD_SHIFT | '5', "SHIFT-5"},
+        {EMOD_SHIFT | '"', "SHIFT-DBLQUOTE"},
+        {EMOD_SHIFT | (FL_F + 4), "SHIFT-F4"},
+        {FL_SCROLL_LOCK | 's', "LAX-s"},
 
 };
 
@@ -108,9 +107,9 @@ TEST(MKeys, StringForBindingCheckModName)
 		bind.key = mapping.code;
 		const char *string = keys::stringForBinding(bind);
 		
-		SString expected = SString(mapping.spaceString) + " browser   CommandName";
-		ASSERT_EQ(expected, string);
-	}
+                SString expected = SString(mapping.dashString) + "\tbrowser\tCommandName";
+                ASSERT_EQ(expected, string);
+        }
 }
 
 TEST(MKeys, ParseKeyString)


### PR DESCRIPTION
## Summary
- render key bindings using tab-separated columns instead of space-padded strings
- configure the preferences dialog to show the key list as a multi-column browser
- adapt key binding unit tests to new format

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b684ed38ac83258528b20d8fb77b75