### PR TITLE
Use column-based key binding list

### DIFF
--- a/changelogs/2.1.0.md
+++ b/changelogs/2.1.0.md
@@ -12,6 +12,7 @@
 * BEHAVIOR, ACS source and SMMU map header lump edits can now be undone.
 * Now Redo has both Ctrl+Y and Ctrl+Shift+Z bindings (Cmd on macOS).
 * Preferences dialog now allows binding multiple modifier keys per action.
+* Improved the view of the key bindings in the Preferences dialog.
 * Now the document dirty status updates correctly when undoing to the same state as last saved.
 * Now on macOS key bindings preferences, show 'CTRL' instead of 'META' for the control key.
 * Corrected high DPI display to actually use the full resolution in the map view.

--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -314,18 +314,6 @@ static SString ModName_Dash(keycode_t mod)
 }
 
 
-static SString ModName_Space(keycode_t mod)
-{
-	SString result = ModName_Dash(mod);
-	if(!result.empty() && result.back() == '-')
-		result.back() = ' ';
-#ifdef __APPLE__
-	if(result == "META ")
-		return "CTRL ";
-#endif
-	return result;
-}
-
 namespace keys
 {
 SString toString(keycode_t key)
@@ -849,12 +837,13 @@ const char * stringForBinding(const key_binding_t& bind, bool changing_key)
 		tempk = toupper(tempk & FL_KEY_MASK);
 	}
 
-	snprintf(buffer, sizeof(buffer), "%s%6.6s%-10.10s %-9.9s %.32s",
-			 bind.is_duplicate ? "@C1" : "",
-			 changing_key ? "<?"     : ModName_Space(tempk).c_str(),
-			 changing_key ? "\077?>" : BareKeyName(tempk & FL_KEY_MASK).c_str(),
-			 ctx_name,
-			 stringForFunc(bind).c_str() );
+	SString key_str = changing_key ? SString("<?>") : toString(tempk);
+
+	snprintf(buffer, sizeof(buffer), "%s%s\t%s\t%s",
+		         bind.is_duplicate ? "@C1" : "",
+		         key_str.c_str(),
+		         ctx_name,
+		         stringForFunc(bind).c_str() );
 
 	return buffer;
 }

--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -819,9 +819,9 @@ SString stringForFunc(const key_binding_t &bind)
 	return buffer;
 }
 
-const char * stringForBinding(const key_binding_t& bind, bool changing_key)
+SString stringForBinding(const key_binding_t& bind, bool changing_key)
 {
-	static char buffer[600];
+	char buffer[256];
 
 	// we prefer the UI to say "3D view" instead of "render"
 	const char *ctx_name = M_KeyContextString(bind.context);

--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -839,10 +839,12 @@ const char * stringForBinding(const key_binding_t& bind, bool changing_key)
 
 	SString key_str = changing_key ? SString("<?>") : toString(tempk);
 
-	snprintf(buffer, sizeof(buffer), "%s%s\t%s\t%s",
+	snprintf(buffer, sizeof(buffer), "%s%s\t%s%s\t%s%s",
 		         bind.is_duplicate ? "@C1" : "",
 		         key_str.c_str(),
+		         bind.is_duplicate ? "@C1" : "",
 		         ctx_name,
+		         bind.is_duplicate ? "@C1" : "",
 		         stringForFunc(bind).c_str() );
 
 	return buffer;

--- a/src/m_keys.cc
+++ b/src/m_keys.cc
@@ -839,13 +839,24 @@ const char * stringForBinding(const key_binding_t& bind, bool changing_key)
 
 	SString key_str = changing_key ? SString("<?>") : toString(tempk);
 
+	auto separateDigitFromColorMarker = [](bool enabled, const SString &str) -> SString
+	{
+		if (!enabled || str.empty())
+			return str;
+
+		if(isdigit(str[0]))
+			return " " + str;
+
+		return str;
+	};
+
 	snprintf(buffer, sizeof(buffer), "%s%s\t%s%s\t%s%s",
 		         bind.is_duplicate ? "@C1" : "",
-		         key_str.c_str(),
+		         separateDigitFromColorMarker(bind.is_duplicate, key_str).c_str(),
 		         bind.is_duplicate ? "@C1" : "",
-		         ctx_name,
+		         separateDigitFromColorMarker(bind.is_duplicate, ctx_name).c_str(),
 		         bind.is_duplicate ? "@C1" : "",
-		         stringForFunc(bind).c_str() );
+		         separateDigitFromColorMarker(bind.is_duplicate, stringForFunc(bind)).c_str());
 
 	return buffer;
 }

--- a/src/m_keys.h
+++ b/src/m_keys.h
@@ -95,7 +95,7 @@ inline constexpr KeyContext validKeyContexts[] =
 	KeyContext::thing,
 	KeyContext::sector,
 	KeyContext::line,
-	
+
 	KeyContext::general
 };
 
@@ -131,7 +131,7 @@ void M_DetectConflictingBinds();
 namespace keys
 {
 SString stringForFunc(const key_binding_t &bind);
-const char * stringForBinding(const key_binding_t& bind, bool changing_key = false);
+SString stringForBinding(const key_binding_t& bind, bool changing_key = false);
 }
 
 void M_GetBindingInfo(int index, keycode_t *key, KeyContext *context);

--- a/src/ui_prefs.cc
+++ b/src/ui_prefs.cc
@@ -862,8 +862,10 @@ UI_Preferences::UI_Preferences(const opt_desc_t *options) :
 		  key_func->callback((Fl_Callback*)sort_key_callback, this);
 		}
 		{ key_list = new Fl_Hold_Browser(20, 115, 442, 308);
-		  key_list->textfont(FL_COURIER);
 		  key_list->has_scrollbar(Fl_Browser_::VERTICAL);
+		  static int widths[] = {125, 75, 205, 0};
+		  key_list->column_widths(widths);
+		  key_list->column_char('\t');
 		}
 		{ key_add = new Fl_Button(480, 155, 85, 30, "&Add");
 		  key_add->callback((Fl_Callback*)edit_key_callback, this);

--- a/test/m_keys_test.cpp
+++ b/test/m_keys_test.cpp
@@ -69,28 +69,28 @@ TEST(MKeys, StringForFunc)
 	editor_command_t command = {"CommandName"};
 	bind.cmd = &command;
 
-	
+
 	// No params
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName");
-	
+
 	bind.param[0] = "parm1";
-	
+
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName: parm1");
-	
+
 	bind.param[1] = "other";
-	
+
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName: parm1 other");
-	
+
 	bind.param[2] = "thing";
-	
+
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName: parm1 other thing");
-	
+
 	bind.param[1].clear();
-	
+
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName: parm1");
-	
+
 	bind.param[1] = "aaaaabbbbbcccccdddddeeeeefffffggggg";
-	
+
 	ASSERT_EQ(keys::stringForFunc(bind), "CommandName: parm1 aaaaabbbbbcccccdddddeeeeefffff thing");
 }
 
@@ -99,14 +99,14 @@ TEST(MKeys, StringForBindingCheckModName)
 	key_binding_t bind = {};
 	editor_command_t command = {"CommandName"};
 	bind.cmd = &command;
-	
+
 	bind.context = KeyContext::browser;
-	
+
 	for(const KeyMapping &mapping : testKeyCombos)
 	{
 		bind.key = mapping.code;
-		const char *string = keys::stringForBinding(bind);
-		
+		SString string = keys::stringForBinding(bind);
+
 		SString expected = SString(mapping.dashString) + "\tbrowser\tCommandName";
 		ASSERT_EQ(expected, string);
 	}
@@ -120,29 +120,29 @@ TEST(MKeys, ParseKeyString)
 	ASSERT_EQ(M_ParseKeyString("9"), static_cast<keycode_t>('9'));
 	ASSERT_EQ(M_ParseKeyString("!"), static_cast<keycode_t>('!'));
 	ASSERT_EQ(M_ParseKeyString(";"), static_cast<keycode_t>(';'));
-	
+
 	ASSERT_EQ(M_ParseKeyString("A"), static_cast<keycode_t>(EMOD_SHIFT | 'a'));
 	ASSERT_EQ(M_ParseKeyString("Z"), static_cast<keycode_t>(EMOD_SHIFT | 'z'));
-	
+
 	ASSERT_EQ(M_ParseKeyString("CMD-a"), static_cast<keycode_t>(EMOD_COMMAND | 'a'));
 	ASSERT_EQ(M_ParseKeyString("CTRL-b"), static_cast<keycode_t>(EMOD_COMMAND | 'b'));
 	ASSERT_EQ(M_ParseKeyString("META-c"), static_cast<keycode_t>(EMOD_META | 'c'));
 	ASSERT_EQ(M_ParseKeyString("ALT-d"), static_cast<keycode_t>(EMOD_ALT | 'd'));
 	ASSERT_EQ(M_ParseKeyString("SHIFT-e"), static_cast<keycode_t>(EMOD_SHIFT | 'e'));
 	ASSERT_EQ(M_ParseKeyString("LAX-f"), static_cast<keycode_t>(FL_SCROLL_LOCK | 'f'));
-	
+
 	ASSERT_EQ(M_ParseKeyString("cmd-a"), static_cast<keycode_t>(EMOD_COMMAND | 'a'));
 	ASSERT_EQ(M_ParseKeyString("Ctrl-B"), static_cast<keycode_t>(EMOD_COMMAND | EMOD_SHIFT | 'b'));
 	ASSERT_EQ(M_ParseKeyString("meta-C"), static_cast<keycode_t>(EMOD_META | EMOD_SHIFT | 'c'));
 	ASSERT_EQ(M_ParseKeyString("Alt-D"), static_cast<keycode_t>(EMOD_ALT | EMOD_SHIFT | 'd'));
 	ASSERT_EQ(M_ParseKeyString("shift-E"), static_cast<keycode_t>(EMOD_SHIFT | EMOD_SHIFT | 'e'));
 	ASSERT_EQ(M_ParseKeyString("lax-F"), static_cast<keycode_t>(FL_SCROLL_LOCK | EMOD_SHIFT | 'f'));
-	
+
 	ASSERT_EQ(M_ParseKeyString("CMD-ALT-g"), static_cast<keycode_t>(EMOD_COMMAND | EMOD_ALT | 'g'));
 	ASSERT_EQ(M_ParseKeyString("SHIFT-CTRL-h"), static_cast<keycode_t>(EMOD_SHIFT | EMOD_COMMAND | 'h'));
 	ASSERT_EQ(M_ParseKeyString("META-SHIFT-i"), static_cast<keycode_t>(EMOD_META | EMOD_SHIFT | 'i'));
 	ASSERT_EQ(M_ParseKeyString("ALT-SHIFT-LAX-j"), static_cast<keycode_t>(EMOD_ALT | EMOD_SHIFT | FL_SCROLL_LOCK | 'j'));
-	
+
 	ASSERT_EQ(M_ParseKeyString("F1"), static_cast<keycode_t>(FL_F + 1));
 	ASSERT_EQ(M_ParseKeyString("F12"), static_cast<keycode_t>(FL_F + 12));
 	ASSERT_EQ(M_ParseKeyString("f3"), static_cast<keycode_t>(FL_F + 3));
@@ -176,17 +176,17 @@ TEST(MKeys, ParseKeyString)
 	ASSERT_EQ(M_ParseKeyString("VOL_DOWN"), static_cast<keycode_t>(FL_Volume_Down));
 	ASSERT_EQ(M_ParseKeyString("WHEEL_UP"), static_cast<keycode_t>(0xEF91));
 	ASSERT_EQ(M_ParseKeyString("WHEEL_DOWN"), static_cast<keycode_t>(0xEF92));
-	
+
 	ASSERT_EQ(M_ParseKeyString("KP_5"), static_cast<keycode_t>(FL_KP + '5'));
 	ASSERT_EQ(M_ParseKeyString("kp_9"), static_cast<keycode_t>(FL_KP + '9'));
 	ASSERT_EQ(M_ParseKeyString("KP_Enter"), static_cast<keycode_t>(FL_KP_Enter));
-	
+
 	ASSERT_EQ(M_ParseKeyString("0x41"), static_cast<keycode_t>(0x41));
 	ASSERT_EQ(M_ParseKeyString("0xFF"), static_cast<keycode_t>(0xFF));
 	ASSERT_EQ(M_ParseKeyString("0x1234"), static_cast<keycode_t>(0x1234));
 	ASSERT_EQ(M_ParseKeyString("0x0"), static_cast<keycode_t>(0x0));
 	ASSERT_EQ(M_ParseKeyString("0xabcd"), static_cast<keycode_t>(0xabcd));
-	
+
 	ASSERT_EQ(M_ParseKeyString(""), 0);
 	ASSERT_EQ(M_ParseKeyString("invalid"), 0);
 	ASSERT_EQ(M_ParseKeyString("NONEXISTENT"), 0);
@@ -196,7 +196,7 @@ TEST(MKeys, ParseKeyString)
 	ASSERT_EQ(M_ParseKeyString("0x"), 0);
 	ASSERT_EQ(M_ParseKeyString("CMD-"), 0);
 	ASSERT_EQ(M_ParseKeyString("SHIFT-"), 0);
-	
+
 	ASSERT_EQ(M_ParseKeyString("~"), static_cast<keycode_t>('~'));
 	ASSERT_EQ(M_ParseKeyString("@"), static_cast<keycode_t>('@'));
 	ASSERT_EQ(M_ParseKeyString("#"), static_cast<keycode_t>('#'));

--- a/test/m_keys_test.cpp
+++ b/test/m_keys_test.cpp
@@ -22,34 +22,33 @@ struct KeyMapping
 {
 	keycode_t code;
 	const char *dashString;
-	const char *spaceString;
 };
 
 // NOTE: keep the old names in the dashed names for backward compatibility
 static const KeyMapping testKeyCombos[] =
 {
-	{EMOD_SHIFT | 'k', "K",                     "      K         "},
+	{EMOD_SHIFT | 'k', "K"},
 	{static_cast<keycode_t>(EMOD_COMMAND) | 'j',
 #ifdef __APPLE__
-		"CMD-j",                                "  CMD j         "
+	        "CMD-j"
 #else
-		"CTRL-j",                               " CTRL j         "
+	        "CTRL-j"
 #endif
 	},
 	{static_cast<keycode_t>(EMOD_META) | 'm',
 #ifdef __APPLE__
-		"META-m",                 " CTRL m         "
+	        "META-m"
 #else
-		"META-m",                 " META m         "
+	        "META-m"
 #endif
 	},
-	{EMOD_ALT | 'a', "ALT-a",                   "  ALT a         "},
-	{EMOD_ALT | (FL_Button + 3), "ALT-MOUSE3",  "  ALT MOUSE3    "},
-	{EMOD_ALT | FL_Volume_Down, "ALT-VOL_DOWN", "  ALT VOL_DOWN  "},
-	{EMOD_SHIFT | '5', "SHIFT-5",               "SHIFT 5         "},
-	{EMOD_SHIFT | '"', "SHIFT-DBLQUOTE",        "SHIFT DBLQUOTE  "},
-	{EMOD_SHIFT | (FL_F + 4), "SHIFT-F4",       "SHIFT F4        "},
-	{FL_SCROLL_LOCK | 's', "LAX-s",             "  LAX s         "},
+	{EMOD_ALT | 'a', "ALT-a"},
+	{EMOD_ALT | (FL_Button + 3), "ALT-MOUSE3"},
+	{EMOD_ALT | FL_Volume_Down, "ALT-VOL_DOWN"},
+	{EMOD_SHIFT | '5', "SHIFT-5"},
+	{EMOD_SHIFT | '"', "SHIFT-DBLQUOTE"},
+	{EMOD_SHIFT | (FL_F + 4), "SHIFT-F4"},
+	{FL_SCROLL_LOCK | 's', "LAX-s"},
 
 };
 
@@ -108,7 +107,7 @@ TEST(MKeys, StringForBindingCheckModName)
 		bind.key = mapping.code;
 		const char *string = keys::stringForBinding(bind);
 		
-		SString expected = SString(mapping.spaceString) + " browser   CommandName";
+		SString expected = SString(mapping.dashString) + "\tbrowser\tCommandName";
 		ASSERT_EQ(expected, string);
 	}
 }


### PR DESCRIPTION
## Summary
- render key bindings using tab-separated columns instead of space-padded strings
- configure the preferences dialog to show the key list as a multi-column browser
- adapt key binding unit tests to new format and use tab indentation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b684ed38ac83258528b20d8fb77b75