### PR TITLE
Gray out Undo/Redo when no history

### DIFF
--- a/src/e_basis.cc
+++ b/src/e_basis.cc
@@ -34,6 +34,7 @@
 #include "SideDef.h"
 #include "Thing.h"
 #include "Vertex.h"
+#include "ui_menu.h"
 
 // need these for the XXX_Notify() prototypes
 #include "r_render.h"
@@ -99,6 +100,8 @@ void Basis::begin()
 		BugError("Basis::begin called twice without Basis::end\n");
 	while(!mRedoFuture.empty())
 		mRedoFuture.pop();
+	if(inst.main_win)
+		menu::setRedoDetail(inst.main_win->menu_bar, "");
 	mCurrentGroup.activate();
 	doClearChangeStatus();
 }
@@ -531,6 +534,8 @@ void Basis::clear()
 		mUndoHistory.pop_back();
 	while(!mRedoFuture.empty())
 		mRedoFuture.pop();
+	if(inst.main_win)
+		menu::setRedoDetail(inst.main_win->menu_bar, "");
 
 	if(inst.main_win)
 	{

--- a/src/ui_menu.cc
+++ b/src/ui_menu.cc
@@ -941,11 +941,17 @@ void setUndoDetail(Fl_Sys_Menu_Bar *bar, const SString &verb)
 	
 	static std::unordered_map<const Fl_Sys_Menu_Bar *, SString> undoDetailStorage;
 	
-	if(verb.good())
+	bool enable = verb.good();
+	if(enable)
 		undoDetailStorage[bar] = SString("&Undo ") + verb;
 	else
 		undoDetailStorage[bar] = "&Undo";
 	bar->replace(index, undoDetailStorage[bar].c_str());
+	int mode = bar->mode(index);
+	if(enable)
+		bar->mode(index, mode & ~FL_MENU_INACTIVE);
+	else
+		bar->mode(index, mode | FL_MENU_INACTIVE);
 }
 
 void setRedoDetail(Fl_Sys_Menu_Bar *bar, const SString &verb)
@@ -958,11 +964,17 @@ void setRedoDetail(Fl_Sys_Menu_Bar *bar, const SString &verb)
 	
 	static std::unordered_map<const Fl_Sys_Menu_Bar *, SString> redoDetailStorage;
 	
-	if(verb.good())
+	bool enable = verb.good();
+	if(enable)
 		redoDetailStorage[bar] = SString("&Redo ") + verb;
 	else
 		redoDetailStorage[bar] = "&Redo";
 	bar->replace(index, redoDetailStorage[bar].c_str());
+	int mode = bar->mode(index);
+	if(enable)
+		bar->mode(index, mode & ~FL_MENU_INACTIVE);
+	else
+		bar->mode(index, mode | FL_MENU_INACTIVE);
 }
 
 Fl_Sys_Menu_Bar *create(int x, int y, int w, int h, void *userData)
@@ -992,6 +1004,8 @@ Fl_Sys_Menu_Bar *create(int x, int y, int w, int h, void *userData)
 			items[i].user_data_ = userData;
 
 	bar->menu(items);
+	setUndoDetail(bar, "");
+	setRedoDetail(bar, "");
 
 	// for macOS, the preferences shall be in the app menu
 #ifdef __APPLE__


### PR DESCRIPTION
## Summary
- Disable Edit->Undo/Redo menu items when there is no corresponding history
- Clear redo menu entry when starting a new edit operation
- Initialize Undo/Redo menu entries disabled on startup

## Testing
- `cmake -S . -B build -G "Unix Makefiles"`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b74cd0cd308325811bdaee0aa58f8a