### PR TITLE
Fixed aarch64 not being detected as little endian

### DIFF
--- a/src/sys_endian.h
+++ b/src/sys_endian.h
@@ -37,6 +37,7 @@
     defined(__ia64__) || defined(__x86_64__)  ||     \
     defined(__alpha__) || defined(__alpha)  ||       \
     defined(__arm__) || defined(__SYMBIAN32__) ||    \
+    defined(__aarch64__) ||                          \
     (defined(__mips__) && defined(__MIPSEL__))
 #define UT_BYTEORDER   UT_LIL_ENDIAN
 #else


### PR DESCRIPTION
This was causing Eureka to blow up on aarch64 as soon as it tried reading a WAD file as it wrongly tried swapping bytes.