### PR TITLE
Rewrite sys_endian to work even on unknown architectures

### DIFF
--- a/src/sys_endian.h
+++ b/src/sys_endian.h
@@ -27,11 +27,14 @@
 
 #pragma once
 
+// for max safety, verify existence of this macro, normally available in C++17
+#if defined(__has_include)
 #if __has_include(<endian.h>)
 #include <endian.h>
 // older BSDs
 #elif __has_include(<sys/endian.h>)
 #include <sys/endian.h>
+#endif
 #endif
 
 #if defined(__APPLE__) && !defined(le16toh)


### PR DESCRIPTION
Use the operating system-provided byteswapping mechanisms
where they exist instead of guessing what endianness we have.

Old code failed to detect aarch64 and still misses all the riscv
variants..