### PR TITLE
Add support for external node builders

### DIFF
--- a/src/Instance.h
+++ b/src/Instance.h
@@ -340,43 +340,43 @@ public:
 	// UI_INFOBAR
 	void Status_Set(EUR_FORMAT_STRING(const char *fmt), ...) const EUR_PRINTF(2, 3);
 	void Status_Clear() const;
-	
+
 	// GridListener
 	void gridRedrawMap() override
 	{
 		RedrawMap();
 	}
-	
+
 	void gridSetGrid(int grid) override
 	{
 		if (main_win)
 			main_win->info_bar->SetGrid(grid);
 	}
-	
+
 	void gridUpdateSnap() override
 	{
 		if (main_win)
 			main_win->info_bar->UpdateSnap();
 	}
-	
+
 	void gridAdjustPos() override
 	{
 		if (main_win)
 			main_win->scroll->AdjustPos();
 	}
-	
+
 	void gridPointerPos() override
 	{
 		if (main_win)
 			main_win->canvas->PointerPos();
 	}
-	
+
 	void gridSetScale(double scale) override
 	{
 		if (main_win)
 			main_win->info_bar->SetScale(scale);
 	}
-	
+
 	void gridBeep(const char *message) override
 	{
 		Beep("%s", message);
@@ -437,7 +437,7 @@ private:
 
 	// M_LOADSAVE
 	void FreshLevel();
-	
+
 	bool M_ExportMap(bool inhibit_node_build);
 	void Navigate2D();
 	void Project_ApplyChanges(const UI_ProjectSetup::Result &result) noexcept(false);
@@ -447,6 +447,7 @@ private:
 	void SaveLevelAndUpdateWindow(LoadingData& loading, const SString& level, Wad_file &wad, bool inhibit_node_build);
 
 	// M_NODES
+	build_result_e RunExternalBuilder();
 	build_result_e BuildAllNodes(nodebuildinfo_t *info);
 
 	// R_GRID
@@ -509,7 +510,7 @@ public:	// will be private when we encapsulate everything
 	int last_given_file = 0;
 	std::optional<UI_NodeDialog> nodeialog;
 	nodebuildinfo_t *nb_info = nullptr;
-	
+
 	int tagInMemory = 0;
 
 	WadData wad;

--- a/src/m_config.cc
+++ b/src/m_config.cc
@@ -245,6 +245,30 @@ const opt_desc_t options[] =
 		&config::bsp_split_factor
 	},
 
+	{	"bsp_use_external",
+		0,
+		OptFlag_preference,
+		"Node building: use external node builder",
+		NULL,
+		&config::bsp_use_external
+	},
+
+	{	"bsp_external_path",
+		0,
+		OptFlag_preference,
+		"Node building: location of external node builder",
+		NULL,
+		&config::bsp_external_path,
+	},
+
+	{	"bsp_external_args",
+		0,
+		OptFlag_preference,
+		"Node building: extra arguments for external node builder",
+		NULL,
+		&config::bsp_external_args,
+	},
+
 	{	"bsp_gl_nodes",
 		0,
 		OptFlag_preference,

--- a/src/m_config.h
+++ b/src/m_config.h
@@ -47,7 +47,7 @@ enum
 	OptFlag_hide = 1 << 4,
 };
 
-typedef std::variant<bool *, int *, rgb_color_t *, SString *, fs::path *, std::vector<SString> *, 
+typedef std::variant<bool *, int *, rgb_color_t *, SString *, fs::path *, std::vector<SString> *,
 					 std::vector<fs::path> *, std::nullptr_t> ArgData;
 
 struct opt_desc_t
@@ -147,6 +147,10 @@ extern bool bsp_on_save;
 extern bool bsp_fast;
 extern bool bsp_warnings;
 extern int  bsp_split_factor;
+
+extern bool bsp_use_external;
+extern SString bsp_external_path;
+extern SString bsp_external_args;
 
 extern bool bsp_gl_nodes;
 extern bool bsp_force_v5;

--- a/src/m_nodes.cc
+++ b/src/m_nodes.cc
@@ -31,6 +31,11 @@
 
 #include "bsp.h"
 
+// needed for external node builder handling, but not on windows
+#ifndef _WIN32
+#include <signal.h>
+#endif
+
 
 // config items
 bool	config::bsp_on_save			= true;
@@ -265,6 +270,78 @@ static void PrepareInfo(nodebuildinfo_t *info)
 	info->cancelled = false;
 }
 
+build_result_e Instance::RunExternalBuilder()
+{
+	gLog.printf("\n");
+
+	SString wad_path = wad.master.editWad()->PathName().u8string();
+
+	SString cmd = SString::printf("%s %s \"%s\" 2>&1",
+								  config::bsp_external_path.c_str(),
+								  config::bsp_external_args.c_str(),
+								  wad_path.c_str());
+
+	GB_PrintMsg("Running external node builder: %s\n", cmd.c_str());
+
+#ifndef _WIN32
+	// take child reaping control over from loop in main.cc; not necessary on windows
+	struct sigaction old_sa = {};
+	struct sigaction new_sa = {};
+	new_sa.sa_handler = SIG_DFL;
+	sigaction(SIGCHLD, &new_sa, &old_sa);
+#endif
+
+#ifdef _WIN32
+	FILE *pipe = _popen(cmd.c_str(), "r");
+#else
+	FILE *pipe = popen(cmd.c_str(), "r");
+#endif
+
+	if (!pipe)
+	{
+		GB_PrintMsg("ERROR: Failed to launch external node builder\n");
+#ifndef _WIN32
+		sigaction(SIGCHLD, &old_sa, nullptr);
+#endif
+		return BUILD_BadFile;
+	}
+
+	char buf[256];
+	while(fgets(buf, sizeof(buf), pipe))
+	{
+		GB_PrintMsg("%s", buf);
+		Fl::check();
+
+		if (nodeialog && nodeialog->WantCancel())
+		{
+#ifdef _WIN32
+			_pclose(pipe);
+#else
+			pclose(pipe);
+			sigaction(SIGCHLD, &old_sa, nullptr);
+#endif
+			return BUILD_Cancelled;
+		}
+	}
+
+#ifdef _WIN32
+		int exit_code = _pclose(pipe);
+#else
+		int exit_code = pclose(pipe);
+		sigaction(SIGCHLD, &old_sa, nullptr);
+		if (WIFEXITED(exit_code))
+			exit_code = WEXITSTATUS(exit_code);
+#endif
+
+		if (exit_code != 0)
+		{
+			GB_PrintMsg("ERROR: external node builder exited with code %d\n", exit_code);
+			return BUILD_BadFile;
+		}
+
+		return BUILD_OK;
+}
+
 build_result_e Instance::BuildAllNodes(nodebuildinfo_t *info)
 {
 	gLog.printf("\n");
@@ -280,50 +357,68 @@ build_result_e Instance::BuildAllNodes(nodebuildinfo_t *info)
 
 	nodeialog->SetProg(0);
 
-	build_result_e ret;
+	build_result_e ret = BUILD_OK;
 
-	// loop over each level in the wad
-	for (int n = 0 ; n < num_levels ; n++)
+	if (config::bsp_use_external)
 	{
-		// load level
 		try
 		{
-			NewDocument newdoc = openDocument(loaded, *wad.master.editWad(), n);
-
-			ret = AJBSP_BuildLevel(info, n, *this, newdoc.doc, newdoc.loading, *wad.master.editWad());
+			wad.master.editWad()->writeToDisk();
 		}
 		catch(const std::runtime_error &e)
 		{
-			GB_PrintMsg("Failed building nodes for level %d: %s\n", n, e.what());
-			continue;
+			GB_PrintMsg("ERROR: could not save %s: %s\n", wad.master.editWad()->PathName().u8string().c_str(), e.what());
+			ret = BUILD_BadFile;
 		}
 
-		// don't fail on maps with overflows
-		// [ Note that 'total_failed_maps' keeps a tally of these ]
-		if (ret == BUILD_LumpOverflow)
-			ret = BUILD_OK;
-
-		if (ret != BUILD_OK)
-			break;
-
-		nodeialog->SetProg(100 * (n + 1) / num_levels);
-
-		Fl::check();
-
-		if (nodeialog->WantCancel())
+		if (ret == BUILD_OK)
+			ret = RunExternalBuilder();
+	}
+	else
+	{
+		// loop over each level in the wad
+		for (int n = 0 ; n < num_levels ; n++)
 		{
-			nb_info->cancelled = true;
-		}
-	}
+			// load level
+			try
+			{
+				NewDocument newdoc = openDocument(loaded, *wad.master.editWad(), n);
 
-	try
-	{
-		wad.master.editWad()->writeToDisk();
-	}
-	catch(const std::runtime_error &e)
-	{
-		GB_PrintMsg("ERROR: could not save %s: %s\n", wad.master.editWad()->PathName().u8string().c_str(), e.what());
-		ret = BUILD_BadFile;
+				ret = AJBSP_BuildLevel(info, n, *this, newdoc.doc, newdoc.loading, *wad.master.editWad());
+			}
+			catch(const std::runtime_error &e)
+			{
+				GB_PrintMsg("Failed building nodes for level %d: %s\n", n, e.what());
+				continue;
+			}
+
+			// don't fail on maps with overflows
+			// [ Note that 'total_failed_maps' keeps a tally of these ]
+			if (ret == BUILD_LumpOverflow)
+				ret = BUILD_OK;
+
+			if (ret != BUILD_OK)
+				break;
+
+			nodeialog->SetProg(100 * (n + 1) / num_levels);
+
+			Fl::check();
+
+			if (nodeialog->WantCancel())
+			{
+				nb_info->cancelled = true;
+			}
+		}
+
+		try
+		{
+			wad.master.editWad()->writeToDisk();
+		}
+		catch(const std::runtime_error &e)
+		{
+			GB_PrintMsg("ERROR: could not save %s: %s\n", wad.master.editWad()->PathName().u8string().c_str(), e.what());
+			ret = BUILD_BadFile;
+		}
 	}
 
 	if (ret == BUILD_OK)
@@ -362,12 +457,17 @@ void Instance::BuildNodesAfterSave(int lev_idx, const LoadingData& loading, Wad_
 
 	PrepareInfo(&nb_info);
 
-	build_result_e ret = AJBSP_BuildLevel(&nb_info, lev_idx, *this, level, loading, wad);
+	build_result_e ret;
+
+	if (config::bsp_use_external)
+		ret = RunExternalBuilder();
+	else
+		ret = AJBSP_BuildLevel(&nb_info, lev_idx, *this, level, loading, wad);
 
 	// TODO : maybe print # of serious/minor warnings
 
 	if (ret != BUILD_OK)
-		gLog.printf("NODES FAILED TO FAILED.\n");
+		gLog.printf("NODES FAILED TO BUILD.\n");
 }
 
 

--- a/src/m_nodes.cc
+++ b/src/m_nodes.cc
@@ -23,6 +23,7 @@
 #include "main.h"
 #include "m_config.h"
 #include "m_loadsave.h"
+#include "m_strings.h"
 #include "e_main.h"
 #include "w_wad.h"
 
@@ -32,16 +33,20 @@
 
 
 // config items
-bool config::bsp_on_save	= true;
-bool config::bsp_fast		= false;
-bool config::bsp_warnings	= false;
+bool	config::bsp_on_save			= true;
+bool	config::bsp_fast			= false;
+bool	config::bsp_warnings		= false;
 
-int  config::bsp_split_factor	= DEFAULT_FACTOR;
+int		config::bsp_split_factor	= DEFAULT_FACTOR;
 
-bool config::bsp_gl_nodes		= true;
-bool config::bsp_force_v5		= false;
-bool config::bsp_force_zdoom	= false;
-bool config::bsp_compressed		= false;
+bool	config::bsp_use_external	= false;
+SString config::bsp_external_path	= "";
+SString config::bsp_external_args	= "";
+
+bool	config::bsp_gl_nodes		= true;
+bool	config::bsp_force_v5		= false;
+bool	config::bsp_force_zdoom		= false;
+bool	config::bsp_compressed		= false;
 
 
 #define NODE_PROGRESS_COLOR  fl_color_cube(2,6,2)
@@ -259,7 +264,6 @@ static void PrepareInfo(nodebuildinfo_t *info)
 	// clear cancelled flag
 	info->cancelled = false;
 }
-
 
 build_result_e Instance::BuildAllNodes(nodebuildinfo_t *info)
 {

--- a/src/m_nodes.cc
+++ b/src/m_nodes.cc
@@ -272,6 +272,11 @@ static void PrepareInfo(nodebuildinfo_t *info)
 
 build_result_e Instance::RunExternalBuilder()
 {
+	if (!wad.master.editWad())
+	{
+		GB_PrintMsg("WAD is not writable, not building nodes\n");
+		return BUILD_OK;
+	}
 	gLog.printf("\n");
 
 	SString wad_path = wad.master.editWad()->PathName().u8string();

--- a/src/ui_prefs.cc
+++ b/src/ui_prefs.cc
@@ -1163,34 +1163,34 @@ UI_Preferences::UI_Preferences(const opt_desc_t *options) :
 		{ nod_warn = new Fl_Check_Button(50, 140, 220, 30, " Warning messages in the logs");
 		}
 
-		{ Fl_Box* o = new Fl_Box(25, 185, 280, 30, "External Node Builder");
+		{ Fl_Box* o = new Fl_Box(25, 180, 280, 30, "External Node Builder");
 		  o->labelfont(FL_BOLD);
 		  o->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
 		}
-		{ nod_use_external = new Fl_Check_Button(50, 220, 440, 30, "Use external node builder   (internal uses AJBSP)");
+		{ nod_use_external = new Fl_Check_Button(50, 215, 440, 30, " Use external node builder   (internal uses AJBSP)");
 		}
-		{ nod_external_path = new Fl_Input(100, 250, 400, 30, "Path");
+		{ nod_external_path = new Fl_Input(100, 245, 400, 30, " Path");
 		  nod_external_path->align(Fl_Align(FL_ALIGN_LEFT));
 		}
-		{ nod_external_args = new Fl_Input(100, 280, 400, 30, "Arguments");
+		{ nod_external_args = new Fl_Input(100, 275, 400, 30, " Arguments");
 		  nod_external_args->align(Fl_Align(FL_ALIGN_LEFT));
 		}
 
-		{ Fl_Box* o = new Fl_Box(25, 325, 250, 30, "Advanced BSP Settings");
+		{ Fl_Box* o = new Fl_Box(25, 315, 250, 30, "Advanced BSP Settings");
 		  o->labelfont(FL_BOLD);
 		  o->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
 		}
-		{ nod_gl_nodes = new Fl_Check_Button(50, 360, 150, 30, " Build GL-Nodes");
+		{ nod_gl_nodes = new Fl_Check_Button(50, 350, 150, 30, " Build GL-Nodes");
 		}
-		{ nod_force_v5 = new Fl_Check_Button(50, 390, 250, 30, " Force V5 of GL-Nodes");
+		{ nod_force_v5 = new Fl_Check_Button(50, 380, 250, 30, " Force V5 of GL-Nodes");
 		}
-		{ nod_force_zdoom = new Fl_Check_Button(50, 420, 250, 30, " Force ZDoom format of normal nodes");
+		{ nod_force_zdoom = new Fl_Check_Button(50, 410, 250, 30, " Force ZDoom format of normal nodes");
 		}
 		// CURRENTLY HIDDEN -- NOT SURE IT IS WORTH HAVING
-		{ nod_compress = new Fl_Check_Button(50, 450, 250, 30, " Force zlib compression");
+		{ nod_compress = new Fl_Check_Button(50, 440, 250, 30, " Force zlib compression");
 		  nod_compress->hide();
 		}
-		{ nod_factor = new Fl_Choice(160, 460, 180, 30, "Seg split logic: ");
+		{ nod_factor = new Fl_Choice(160, 450, 180, 30, "Seg split logic: ");
 		  nod_factor->add("NORMAL|Minimize Splits|Balance BSP Tree");
 		}
 		o->end();

--- a/src/ui_prefs.cc
+++ b/src/ui_prefs.cc
@@ -616,7 +616,7 @@ private:
 			// Only push a snapshot if something actually changed
 			if(before == after)
 				return;
-			
+
 			Snapshot s;
 			s.before = std::move(before);
 			s.after = std::move(after);
@@ -804,6 +804,10 @@ public:
 	Fl_Check_Button *nod_warn;
 
 	Fl_Choice *nod_factor;
+
+	Fl_Check_Button *nod_use_external;
+	Fl_Input        *nod_external_path;
+	Fl_Input        *nod_external_args;
 
 	Fl_Check_Button *nod_gl_nodes;
 	Fl_Check_Button *nod_force_v5;
@@ -1159,21 +1163,34 @@ UI_Preferences::UI_Preferences(const opt_desc_t *options) :
 		{ nod_warn = new Fl_Check_Button(50, 140, 220, 30, " Warning messages in the logs");
 		}
 
-		{ Fl_Box* o = new Fl_Box(25, 205, 250, 30, "Advanced BSP Settings");
+		{ Fl_Box* o = new Fl_Box(25, 185, 280, 30, "External Node Builder");
 		  o->labelfont(FL_BOLD);
 		  o->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
 		}
-		{ nod_gl_nodes = new Fl_Check_Button(50, 245, 150, 30, " Build GL-Nodes");
+		{ nod_use_external = new Fl_Check_Button(50, 220, 440, 30, "Use external node builder   (internal uses AJBSP)");
 		}
-		{ nod_force_v5 = new Fl_Check_Button(50, 275, 250, 30, " Force V5 of GL-Nodes");
+		{ nod_external_path = new Fl_Input(100, 250, 400, 30, "Path");
+		  nod_external_path->align(Fl_Align(FL_ALIGN_LEFT));
 		}
-		{ nod_force_zdoom = new Fl_Check_Button(50, 305, 250, 30, " Force ZDoom format of normal nodes");
+		{ nod_external_args = new Fl_Input(100, 280, 400, 30, "Arguments");
+		  nod_external_args->align(Fl_Align(FL_ALIGN_LEFT));
+		}
+
+		{ Fl_Box* o = new Fl_Box(25, 325, 250, 30, "Advanced BSP Settings");
+		  o->labelfont(FL_BOLD);
+		  o->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
+		}
+		{ nod_gl_nodes = new Fl_Check_Button(50, 360, 150, 30, " Build GL-Nodes");
+		}
+		{ nod_force_v5 = new Fl_Check_Button(50, 390, 250, 30, " Force V5 of GL-Nodes");
+		}
+		{ nod_force_zdoom = new Fl_Check_Button(50, 420, 250, 30, " Force ZDoom format of normal nodes");
 		}
 		// CURRENTLY HIDDEN -- NOT SURE IT IS WORTH HAVING
-		{ nod_compress = new Fl_Check_Button(50, 335, 250, 30, " Force zlib compression");
+		{ nod_compress = new Fl_Check_Button(50, 450, 250, 30, " Force zlib compression");
 		  nod_compress->hide();
 		}
-		{ nod_factor = new Fl_Choice(160, 345, 180, 30, "Seg split logic: ");
+		{ nod_factor = new Fl_Choice(160, 460, 180, 30, "Seg split logic: ");
 		  nod_factor->add("NORMAL|Minimize Splits|Balance BSP Tree");
 		}
 		o->end();
@@ -1618,6 +1635,10 @@ void UI_Preferences::LoadValues()
 	else
 		nod_factor->value(0);	// NORMAL
 
+	nod_use_external->value(config::bsp_use_external ? 1 : 0);
+	nod_external_path->value(config::bsp_external_path.c_str());
+	nod_external_args->value(config::bsp_external_args.c_str());
+
 	nod_gl_nodes->value(config::bsp_gl_nodes ? 1 : 0);
 	nod_force_v5->value(config::bsp_force_v5 ? 1 : 0);
 	nod_force_zdoom->value(config::bsp_force_zdoom ? 1 : 0);
@@ -1754,6 +1775,10 @@ void UI_Preferences::SaveValues()
 		config::bsp_split_factor = 2;
 	else
 		config::bsp_split_factor = 11;
+
+	config::bsp_use_external = nod_use_external->value() ? true : false;
+	config::bsp_external_path = nod_external_path->value();
+	config::bsp_external_args = nod_external_args->value();
 
 	config::bsp_gl_nodes = nod_gl_nodes->value() ? true : false;
 	config::bsp_force_v5 = nod_force_v5->value() ? true : false;


### PR DESCRIPTION
Does what it says on the tin. Includes basic setup GUI with the other node builder settings:

<img width="628" height="572" alt="image" src="https://github.com/user-attachments/assets/1ea2730c-01b3-4042-bf1e-ca114becfa50" />

Also prints external node builder output to the log viewer. Tested on Linux with ZokumBSP (actually a wrapper for ZokumBSP since it likes to throw a fit if it doesn't find node builder lumps on Linux), but should work on any desktop with any node builder.